### PR TITLE
년도, 월 별에 따른(다이얼로그, 버튼 이동) 수입, 지출 내역 기능

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,4 +68,7 @@ dependencies {
     kapt "com.google.dagger:hilt-android-compiler:$hilt_version"
     implementation "androidx.hilt:hilt-lifecycle-viewmodel:$hilt_lifecycle_viewmodel"
     kapt "androidx.hilt:hilt-compiler:$hilt_compiler"
+
+    implementation "com.chargemap.compose:numberpicker:1.0.3"
+
 }

--- a/app/src/main/java/com/woowa/accountbook/common/Constants.kt
+++ b/app/src/main/java/com/woowa/accountbook/common/Constants.kt
@@ -1,0 +1,6 @@
+package com.woowa.accountbook.common
+
+import java.util.*
+
+val NOW_YEAR = Calendar.getInstance().get(Calendar.YEAR)
+val NOW_MONTH = Calendar.getInstance().get(Calendar.MONTH) + 1

--- a/app/src/main/java/com/woowa/accountbook/common/TextFormat.kt
+++ b/app/src/main/java/com/woowa/accountbook/common/TextFormat.kt
@@ -1,4 +1,4 @@
-package com.woowa.accountbook.ui.util
+package com.woowa.accountbook.common
 
 import java.text.DecimalFormat
 
@@ -7,4 +7,8 @@ fun rawToMoneyFormat(money: Int, isIncome: Int): String {
     val decimalFormat = DecimalFormat("#,###")
     val result = decimalFormat.format(money)
     return if (isIncome == 1) result else "-$result"
+}
+
+fun rawToYearAndMonth(year: Int, month: Int): String {
+    return "${year}년 ${month}월"
 }

--- a/app/src/main/java/com/woowa/accountbook/di/AppModule.kt
+++ b/app/src/main/java/com/woowa/accountbook/di/AppModule.kt
@@ -1,0 +1,19 @@
+package com.woowa.accountbook.di
+
+import com.woowa.accountbook.ui.calendar.CustomCalendar
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AppModule {
+
+    @Provides
+    @Singleton
+    fun provideCustomCalendar(): CustomCalendar {
+        return CustomCalendar()
+    }
+}

--- a/app/src/main/java/com/woowa/accountbook/ui/calendar/CalendarViewModel.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/calendar/CalendarViewModel.kt
@@ -1,0 +1,34 @@
+package com.woowa.accountbook.ui.calendar
+
+import androidx.lifecycle.ViewModel
+import com.woowa.accountbook.common.rawToYearAndMonth
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class CalendarViewModel @Inject constructor(private val calendar: CustomCalendar) : ViewModel() {
+
+    private val _yearAndMonth = MutableStateFlow(calendar.currentYearAndMonth)
+    val yearAndMonth: StateFlow<String> get() = _yearAndMonth
+
+    private val _yearMonthPair = MutableStateFlow(calendar.yearMonthPair)
+    val yearMonthPair: StateFlow<Pair<Int, Int>> get() = _yearMonthPair
+
+    fun setYearAndMonth(year: Int, month: Int) {
+        calendar.setYearAndMonth(year, month)
+        _yearAndMonth.value = rawToYearAndMonth(year, month)
+        _yearMonthPair.value = calendar.yearMonthPair
+    }
+
+    fun previousYearAndMonth() {
+        _yearAndMonth.value = calendar.previousYearAndMonth()
+        _yearMonthPair.value = calendar.yearMonthPair
+    }
+
+    fun nextYearAndMonth() {
+        _yearAndMonth.value = calendar.nextYearAndMonth()
+        _yearMonthPair.value = calendar.yearMonthPair
+    }
+}

--- a/app/src/main/java/com/woowa/accountbook/ui/calendar/CalendarViewModel.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/calendar/CalendarViewModel.kt
@@ -17,8 +17,7 @@ class CalendarViewModel @Inject constructor(private val calendar: CustomCalendar
     val yearMonthPair: StateFlow<Pair<Int, Int>> get() = _yearMonthPair
 
     fun setYearAndMonth(year: Int, month: Int) {
-        calendar.setYearAndMonth(year, month)
-        _yearAndMonth.value = rawToYearAndMonth(year, month)
+        _yearAndMonth.value = calendar.setYearAndMonth(year, month)
         _yearMonthPair.value = calendar.yearMonthPair
     }
 

--- a/app/src/main/java/com/woowa/accountbook/ui/calendar/CustomCalendar.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/calendar/CustomCalendar.kt
@@ -12,10 +12,11 @@ class CustomCalendar {
     val currentYearAndMonth = "${NOW_YEAR}년 ${NOW_MONTH}월"
     var yearMonthPair = Pair(NOW_YEAR, NOW_MONTH)
 
-    fun setYearAndMonth(year: Int, month: Int) {
+    fun setYearAndMonth(year: Int, month: Int): String {
         calendar.set(Calendar.YEAR, year)
         calendar.set(Calendar.MONTH, month - 1)
         yearMonthPair = Pair(year, month - 1)
+        return rawToYearAndMonth(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH) + 1)
     }
 
     fun previousYearAndMonth(): String {

--- a/app/src/main/java/com/woowa/accountbook/ui/calendar/CustomCalendar.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/calendar/CustomCalendar.kt
@@ -1,0 +1,50 @@
+package com.woowa.accountbook.ui.calendar
+
+import com.woowa.accountbook.common.NOW_MONTH
+import com.woowa.accountbook.common.NOW_YEAR
+import com.woowa.accountbook.common.rawToYearAndMonth
+import java.util.*
+
+class CustomCalendar {
+
+    private val calendar = Calendar.getInstance()
+
+    val currentYearAndMonth = "${NOW_YEAR}년 ${NOW_MONTH}월"
+    var yearMonthPair = Pair(NOW_YEAR, NOW_MONTH)
+
+    fun setYearAndMonth(year: Int, month: Int) {
+        calendar.set(Calendar.YEAR, year)
+        calendar.set(Calendar.MONTH, month - 1)
+        yearMonthPair = Pair(year, month - 1)
+    }
+
+    fun previousYearAndMonth(): String {
+        val year = calendar.get(Calendar.YEAR)
+        val month = calendar.get(Calendar.MONTH)
+
+        if (month == 0) {
+            calendar.set(Calendar.YEAR, year - 1)
+            calendar.set(Calendar.MONTH, 11)
+        } else {
+            calendar.set(Calendar.MONTH, month - 1)
+        }
+        yearMonthPair = Pair(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH) + 1)
+        return rawToYearAndMonth(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH) + 1)
+    }
+
+    fun nextYearAndMonth(): String {
+        val year = calendar.get(Calendar.YEAR)
+        val month = calendar.get(Calendar.MONTH)
+
+        if (month == 12) {
+            calendar.set(Calendar.YEAR, year + 1)
+            calendar.set(Calendar.MONTH, 0)
+        } else {
+            calendar.set(Calendar.MONTH, month + 1)
+        }
+        yearMonthPair = Pair(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH) + 1)
+        return rawToYearAndMonth(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH) + 1)
+    }
+
+
+}

--- a/app/src/main/java/com/woowa/accountbook/ui/component/AppBar.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/component/AppBar.kt
@@ -1,12 +1,13 @@
 package com.woowa.accountbook.ui.component
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -28,8 +29,10 @@ fun AccountBookAppBar(
     actionIcon: ImageVector?,
     onActionClicked: () -> Unit,
     backgroundColor: Color = OffWhite,
-    contentColor: Color = Purple
+    contentColor: Color = Purple,
+    dialog: @Composable (Boolean, (Boolean) -> Unit) -> Unit = { _, _ -> }
 ) {
+    var isShowDialog by remember { mutableStateOf(false) }
     TopAppBar(
         backgroundColor = backgroundColor,
         contentColor = contentColor,
@@ -42,7 +45,8 @@ fun AccountBookAppBar(
                             .padding(end = 72.dp - 4.dp)
                     }
                     else -> Modifier.fillMaxWidth()
-                },
+                }
+                    .clickable { isShowDialog = !isShowDialog },
                 textAlign = TextAlign.Center,
                 style = Typography.subtitle1,
                 maxLines = 1,
@@ -68,6 +72,7 @@ fun AccountBookAppBar(
             }
         }
     )
+    dialog(isShowDialog) { isShowDialog = !it }
 }
 
 @Preview(showBackground = true)
@@ -78,7 +83,8 @@ fun AccountBookAppBarPreview() {
         navigationIcon = IconPack.LeftArrow,
         onNavigationClicked = {},
         actionIcon = IconPack.RightArrow,
-        onActionClicked = {}
+        onActionClicked = {},
+        dialog = { _, _ -> }
     )
 }
 
@@ -90,7 +96,8 @@ fun AccountBookRegistrationAppBar() {
         navigationIcon = IconPack.LeftArrow,
         onNavigationClicked = {},
         actionIcon = null,
-        onActionClicked = {}
+        onActionClicked = {},
+        dialog = { _, _ -> }
     )
 }
 
@@ -102,6 +109,7 @@ fun AccountBookSettingAppBar() {
         navigationIcon = null,
         onNavigationClicked = {},
         actionIcon = null,
-        onActionClicked = {}
+        onActionClicked = {},
+        dialog = { _, _ -> }
     )
 }

--- a/app/src/main/java/com/woowa/accountbook/ui/component/Dialog.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/component/Dialog.kt
@@ -1,0 +1,99 @@
+package com.woowa.accountbook.ui.component
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.chargemap.compose.numberpicker.NumberPicker
+import com.woowa.accountbook.ui.theme.White
+import com.woowa.accountbook.ui.theme.Yellow
+
+@Composable
+fun AccountBookDialog(
+    isShow: Boolean,
+    onDismissRequest: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable (Boolean) -> Unit = {}
+) {
+    if (isShow) {
+        Dialog(onDismissRequest = { onDismissRequest(isShow) }) {
+            Surface(
+                modifier = modifier,
+                color = White
+            ) {
+                content(isShow)
+            }
+        }
+    }
+}
+
+@Composable
+fun YearAndMonthPicker(
+    year: Int,
+    month: Int,
+    onClicked: (Int, Int) -> Unit
+) {
+    Column(
+        modifier = Modifier.padding(20.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        var selectedYear = year
+        var selectedMonth = month
+        Row(
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            DateNumberPicker(1000..9999, year, onCompleted = { selectedYear = it })
+            Spacer(modifier = Modifier.width(30.dp))
+            DateNumberPicker(1..12, month, onCompleted = { selectedMonth = it })
+        }
+        TextButton(
+            text = "완료",
+            textColor = White,
+            modifier = Modifier
+                .fillMaxWidth(),
+            shape = RoundedCornerShape(14.dp),
+            onClicked = {
+                onClicked(selectedYear, selectedMonth)
+            },
+            isClick = true,
+            clickBackgroundColor = Yellow,
+            unClickBackgroundColor = Yellow
+        )
+    }
+}
+
+@Composable
+fun DateNumberPicker(
+    intRange: IntRange,
+    value: Int,
+    onCompleted: (Int) -> Unit
+) {
+    val pickerState = remember { mutableStateOf(value) }
+    NumberPicker(
+        modifier = Modifier.width(200.dp),
+        value = pickerState.value,
+        onValueChange = {
+            pickerState.value = it
+            onCompleted(it)
+        },
+        range = intRange
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun AccountBookDialogPreview() {
+    AccountBookDialog(
+        isShow = true,
+        onDismissRequest = {},
+        content = { YearAndMonthPicker(0, 0, onClicked = { year, month -> }) }
+    )
+}

--- a/app/src/main/java/com/woowa/accountbook/ui/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/history/HistoryViewModel.kt
@@ -1,13 +1,11 @@
 package com.woowa.accountbook.ui.history
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.woowa.accountbook.data.entitiy.History
 import com.woowa.accountbook.data.repository.Repository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -16,10 +14,6 @@ class HistoryViewModel @Inject constructor(private val repository: Repository) :
     private val totalHistory = MutableStateFlow<List<History>>(emptyList())
     private val _history = MutableStateFlow<List<History>>(emptyList())
     val history: StateFlow<List<History>> get() = _history
-
-    init {
-        getHistory(7)
-    }
 
     fun getHistory(month: Int) {
         val result = repository.getHistory(month).getOrThrow()

--- a/app/src/main/java/com/woowa/accountbook/ui/history/component/HistoryScreen.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/history/component/HistoryScreen.kt
@@ -19,10 +19,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.woowa.accountbook.common.rawToMoneyFormat
 import com.woowa.accountbook.data.entitiy.History
 import com.woowa.accountbook.ui.calendar.CalendarViewModel
-import com.woowa.accountbook.ui.component.AccountBookAppBar
-import com.woowa.accountbook.ui.component.LabelText
-import com.woowa.accountbook.ui.component.LeftCornerCheckButton
-import com.woowa.accountbook.ui.component.RightCornerCheckButton
+import com.woowa.accountbook.ui.component.*
 import com.woowa.accountbook.ui.history.HistoryViewModel
 import com.woowa.accountbook.ui.iconpack.IconPack
 import com.woowa.accountbook.ui.iconpack.LeftArrow
@@ -35,7 +32,7 @@ fun HistoryScreen(
     calendarViewModel: CalendarViewModel = hiltViewModel()
 ) {
     val yearAndMonth = calendarViewModel.yearAndMonth.collectAsState().value
-    val (_, month) = calendarViewModel.yearMonthPair.value
+    val (year, month) = calendarViewModel.yearMonthPair.value
     historyViewModel.getHistory(month)
     val inComeIsChecked = remember { mutableStateOf(true) }
     val expenseIsChecked = remember { mutableStateOf(true) }
@@ -56,6 +53,26 @@ fun HistoryScreen(
                     calendarViewModel.nextYearAndMonth()
                     inComeIsChecked.value = true
                     expenseIsChecked.value = true
+                },
+                dialog = { isShow, onDismissRequest ->
+                    AccountBookDialog(
+                        isShow = isShow,
+                        onDismissRequest = { onDismissRequest(it) },
+                        modifier = Modifier
+                            .fillMaxWidth(),
+                        content = {
+                            YearAndMonthPicker(
+                                year,
+                                month,
+                                onClicked = { year, month ->
+                                    onDismissRequest(it)
+                                    calendarViewModel.setYearAndMonth(year, month)
+                                    inComeIsChecked.value = true
+                                    expenseIsChecked.value = true
+                                }
+                            )
+                        }
+                    )
                 }
             )
         }
@@ -77,7 +94,7 @@ fun HistoryScreen(
                 onExpenseButtonClicked = { expenseIsChecked.value = !expenseIsChecked.value },
                 onIncomeClicked = { historyViewModel.getIncomeHistory() },
                 onExpenseClicked = { historyViewModel.getExpenseHistory() },
-                onBothClicked = { historyViewModel.getHistory(7) },
+                onBothClicked = { historyViewModel.getHistory(month) },
                 onEmptyClicked = { historyViewModel.getEmptyHistory() }
             )
             if (groupHistory.isEmpty() || (!inComeIsChecked.value && !expenseIsChecked.value)) {

--- a/app/src/main/java/com/woowa/accountbook/ui/history/component/HistoryScreen.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/history/component/HistoryScreen.kt
@@ -16,7 +16,9 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.woowa.accountbook.common.rawToMoneyFormat
 import com.woowa.accountbook.data.entitiy.History
+import com.woowa.accountbook.ui.calendar.CalendarViewModel
 import com.woowa.accountbook.ui.component.AccountBookAppBar
 import com.woowa.accountbook.ui.component.LabelText
 import com.woowa.accountbook.ui.component.LeftCornerCheckButton
@@ -26,19 +28,35 @@ import com.woowa.accountbook.ui.iconpack.IconPack
 import com.woowa.accountbook.ui.iconpack.LeftArrow
 import com.woowa.accountbook.ui.iconpack.RightArrow
 import com.woowa.accountbook.ui.theme.*
-import com.woowa.accountbook.ui.util.rawToMoneyFormat
 
 @Composable
-fun HistoryScreen(historyViewModel: HistoryViewModel = hiltViewModel()) {
+fun HistoryScreen(
+    historyViewModel: HistoryViewModel = hiltViewModel(),
+    calendarViewModel: CalendarViewModel = hiltViewModel()
+) {
+    val yearAndMonth = calendarViewModel.yearAndMonth.collectAsState().value
+    val (_, month) = calendarViewModel.yearMonthPair.value
+    historyViewModel.getHistory(month)
+    val inComeIsChecked = remember { mutableStateOf(true) }
+    val expenseIsChecked = remember { mutableStateOf(true) }
+
     Scaffold(
         backgroundColor = OffWhite,
         topBar = {
             AccountBookAppBar(
-                title = "2022년 7월",
+                title = yearAndMonth,
                 navigationIcon = IconPack.LeftArrow,
-                onNavigationClicked = {},
+                onNavigationClicked = {
+                    calendarViewModel.previousYearAndMonth()
+                    inComeIsChecked.value = true
+                    expenseIsChecked.value = true
+                },
                 actionIcon = IconPack.RightArrow,
-                onActionClicked = {}
+                onActionClicked = {
+                    calendarViewModel.nextYearAndMonth()
+                    inComeIsChecked.value = true
+                    expenseIsChecked.value = true
+                }
             )
         }
     ) {
@@ -46,8 +64,6 @@ fun HistoryScreen(historyViewModel: HistoryViewModel = hiltViewModel()) {
         val groupHistory = histories.groupBy { it.day }
         val monthTotalIncome = histories.filter { it.category.isIncome == 1 }.sumOf { it.money }
         val monthTotalExpense = histories.filter { it.category.isIncome == 0 }.sumOf { it.money }
-        val inComeIsChecked = remember { mutableStateOf(true) }
-        val expenseIsChecked = remember { mutableStateOf(true) }
 
         Column(modifier = Modifier.fillMaxSize()) {
             HistoryFilterButton(


### PR DESCRIPTION
### Issue

- closed #19 

### Description

- AppBar 의 Navigation, Action 이벤트 처리
  - Navigation 으로 이전 달, 이전 년도로 이동
  - Action 으로 다음 달, 다음 년도로 이동

- 달력을 관리할 CustomCalendar 구현
  - 년도, 월 별 이동을 위해 캘린더 데이터 생성
  - AppBar 다이얼로그을 통해 이동하기 위해 캘린더 데이터 생성

- NumberPicker 라이브러리 추가