### PR TITLE
수입, 지출 필터체크박스 공통 컴포넌트로 관리

### DIFF
--- a/app/src/main/java/com/woowa/accountbook/ui/component/Button.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/component/Button.kt
@@ -4,12 +4,14 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.woowa.accountbook.common.rawToMoneyFormat
 import com.woowa.accountbook.ui.iconpack.IconPack
 import com.woowa.accountbook.ui.iconpack.Plus
 import com.woowa.accountbook.ui.theme.*
@@ -169,6 +171,98 @@ fun RightCornerCheckButton(
 }
 
 @Composable
+fun FilterCheckBoxButton(
+    totalIncome: Int,
+    totalExpense: Int,
+    inComeIsChecked: MutableState<Boolean>,
+    expenseIsChecked: MutableState<Boolean>,
+    enabled: Boolean,
+    onIncomeCheckBoxClicked: (Boolean) -> Unit,
+    onExpenseCheckBoxClicked: (Boolean) -> Unit,
+    onIncomeButtonClicked: () -> Unit,
+    onExpenseButtonClicked: () -> Unit,
+    onIncomeClicked: () -> Unit,
+    onExpenseClicked: () -> Unit,
+    onBothClicked: () -> Unit,
+    onEmptyClicked: () -> Unit
+) {
+    Spacer(modifier = Modifier.height(16.dp))
+    Row(
+        modifier = Modifier
+            .fillMaxWidth(),
+        horizontalArrangement = Arrangement.Center
+    ) {
+        LeftCornerCheckButton(
+            enabled = enabled,
+            checkBox = true,
+            checked = inComeIsChecked.value,
+            onClicked = {
+                onIncomeButtonClicked()
+                onClickFilterButton(
+                    inComeIsChecked,
+                    expenseIsChecked,
+                    onBothClicked,
+                    onIncomeClicked,
+                    onExpenseClicked,
+                    onEmptyClicked
+                )
+            },
+            onCheckedChange = {
+                onIncomeCheckBoxClicked(it)
+                onClickFilterButton(
+                    inComeIsChecked,
+                    expenseIsChecked,
+                    onBothClicked,
+                    onIncomeClicked,
+                    onExpenseClicked,
+                    onEmptyClicked
+                )
+            },
+            disabledColor = White,
+            checkedColor = White,
+            uncheckedColor = White,
+            checkmarkColor = Purple,
+            labelText = "수입",
+            labelPriceText = rawToMoneyFormat(totalIncome, 1)
+        )
+
+        RightCornerCheckButton(
+            enabled = enabled,
+            checkBox = true,
+            checked = expenseIsChecked.value,
+            onClicked = {
+                onExpenseButtonClicked()
+                onClickFilterButton(
+                    inComeIsChecked,
+                    expenseIsChecked,
+                    onBothClicked,
+                    onIncomeClicked,
+                    onExpenseClicked,
+                    onEmptyClicked
+                )
+            },
+            onCheckedChange = {
+                onExpenseCheckBoxClicked(it)
+                onClickFilterButton(
+                    inComeIsChecked,
+                    expenseIsChecked,
+                    onBothClicked,
+                    onIncomeClicked,
+                    onExpenseClicked,
+                    onEmptyClicked
+                )
+            },
+            disabledColor = White,
+            checkedColor = White,
+            uncheckedColor = White,
+            checkmarkColor = Purple,
+            labelText = "지출",
+            labelPriceText = rawToMoneyFormat(totalExpense, 0)
+        )
+    }
+}
+
+@Composable
 fun TextButton(
     text: String,
     textColor: Color,
@@ -197,6 +291,20 @@ fun TextButton(
             color = textColor
         )
     }
+}
+
+private fun onClickFilterButton(
+    inComeIsChecked: MutableState<Boolean>,
+    expenseIsChecked: MutableState<Boolean>,
+    onBothClicked: () -> Unit,
+    onIncomeClicked: () -> Unit,
+    onExpenseClicked: () -> Unit,
+    onEmptyClicked: () -> Unit
+) {
+    if (inComeIsChecked.value && expenseIsChecked.value) onBothClicked()
+    else if (inComeIsChecked.value) onIncomeClicked()
+    else if (expenseIsChecked.value) onExpenseClicked()
+    else onEmptyClicked()
 }
 
 @Preview(showBackground = false)

--- a/app/src/main/java/com/woowa/accountbook/ui/history/component/HistoryScreen.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/history/component/HistoryScreen.kt
@@ -100,7 +100,7 @@ fun HistoryScreen(
             totalViewModel.filter { it.category.isIncome == 0 }.sumOf { it.money }
 
         Column(modifier = Modifier.fillMaxSize()) {
-            HistoryFilterButton(
+            FilterCheckBoxButton(
                 totalIncome = monthTotalIncome,
                 totalExpense = monthTotalExpense,
                 inComeIsChecked = inComeIsChecked,
@@ -186,112 +186,6 @@ private fun HistoryLazyColumn(
         }
 
     }
-}
-
-@Composable
-private fun HistoryFilterButton(
-    totalIncome: Int,
-    totalExpense: Int,
-    inComeIsChecked: MutableState<Boolean>,
-    expenseIsChecked: MutableState<Boolean>,
-    enabled: Boolean,
-    onIncomeCheckBoxClicked: (Boolean) -> Unit,
-    onExpenseCheckBoxClicked: (Boolean) -> Unit,
-    onIncomeButtonClicked: () -> Unit,
-    onExpenseButtonClicked: () -> Unit,
-    onIncomeClicked: () -> Unit,
-    onExpenseClicked: () -> Unit,
-    onBothClicked: () -> Unit,
-    onEmptyClicked: () -> Unit
-) {
-    Spacer(modifier = Modifier.height(16.dp))
-    Row(
-        modifier = Modifier
-            .fillMaxWidth(),
-        horizontalArrangement = Arrangement.Center
-    ) {
-        LeftCornerCheckButton(
-            enabled = enabled,
-            checkBox = true,
-            checked = inComeIsChecked.value,
-            onClicked = {
-                onIncomeButtonClicked()
-                onClickFilterButton(
-                    inComeIsChecked,
-                    expenseIsChecked,
-                    onBothClicked,
-                    onIncomeClicked,
-                    onExpenseClicked,
-                    onEmptyClicked
-                )
-            },
-            onCheckedChange = {
-                onIncomeCheckBoxClicked(it)
-                onClickFilterButton(
-                    inComeIsChecked,
-                    expenseIsChecked,
-                    onBothClicked,
-                    onIncomeClicked,
-                    onExpenseClicked,
-                    onEmptyClicked
-                )
-            },
-            disabledColor = White,
-            checkedColor = White,
-            uncheckedColor = White,
-            checkmarkColor = Purple,
-            labelText = "수입",
-            labelPriceText = rawToMoneyFormat(totalIncome, 1)
-        )
-
-        RightCornerCheckButton(
-            enabled = enabled,
-            checkBox = true,
-            checked = expenseIsChecked.value,
-            onClicked = {
-                onExpenseButtonClicked()
-                onClickFilterButton(
-                    inComeIsChecked,
-                    expenseIsChecked,
-                    onBothClicked,
-                    onIncomeClicked,
-                    onExpenseClicked,
-                    onEmptyClicked
-                )
-            },
-            onCheckedChange = {
-                onExpenseCheckBoxClicked(it)
-                onClickFilterButton(
-                    inComeIsChecked,
-                    expenseIsChecked,
-                    onBothClicked,
-                    onIncomeClicked,
-                    onExpenseClicked,
-                    onEmptyClicked
-                )
-            },
-            disabledColor = White,
-            checkedColor = White,
-            uncheckedColor = White,
-            checkmarkColor = Purple,
-            labelText = "지출",
-            labelPriceText = rawToMoneyFormat(totalExpense, 0)
-        )
-    }
-}
-
-private fun onClickFilterButton(
-    inComeIsChecked: MutableState<Boolean>,
-    expenseIsChecked: MutableState<Boolean>,
-    onBothClicked: () -> Unit,
-    onIncomeClicked: () -> Unit,
-    onExpenseClicked: () -> Unit,
-    onEmptyClicked: () -> Unit
-) {
-    if (inComeIsChecked.value && expenseIsChecked.value) onBothClicked()
-    else if (inComeIsChecked.value) onIncomeClicked()
-    else if (expenseIsChecked.value) onExpenseClicked()
-    else onEmptyClicked()
 }
 
 @Preview(showBackground = true)


### PR DESCRIPTION
### Issue

- closed #26 

### Description

- 내역 화면에서 FilterCheckBoxButton을 직접 관리 → 공통 버튼 컴포넌트로 이동
  - 추후 재사용이 될 수도 있음을 판단하고 이동하면 좋을 것으로 판단
  - history/component/HistoryScreen → component/Button.kt