### PR TITLE
통계 화면 구성하기

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,4 +71,5 @@ dependencies {
 
     implementation "com.chargemap.compose:numberpicker:1.0.3"
 
+    implementation "com.github.PhilJay:MPAndroidChart:v3.1.0"
 }

--- a/app/src/main/java/com/woowa/accountbook/data/local/history/HistoryLocalDataSource.kt
+++ b/app/src/main/java/com/woowa/accountbook/data/local/history/HistoryLocalDataSource.kt
@@ -108,7 +108,7 @@ class HistoryLocalDataSource @Inject constructor(
         databaseHelper.readableDatabase.use { database ->
             val isIncome = if (type) "1" else "0"
             val sql =
-                "SELECT * FROM (SELECT * FROM ${DatabaseHelper.TABLE_ACCOUNT_BOOK} ORDER BY ${DatabaseHelper.ACCOUNT_BOOK_COL_MONTH} DESC) as T, ${DatabaseHelper.TABLE_CATEGORY}, ${DatabaseHelper.TABLE_PAYMENT} WHERE T.${DatabaseHelper.ACCOUNT_BOOK_COL_CATEGORY} = ${DatabaseHelper.TABLE_CATEGORY}.${DatabaseHelper.CATEGORY_COL_ID} AND T.${DatabaseHelper.ACCOUNT_BOOK_COL_PAYMENT} = ${DatabaseHelper.TABLE_PAYMENT}.${DatabaseHelper.PAYMENT_COL_ID} AND ${DatabaseHelper.TABLE_CATEGORY}.${DatabaseHelper.CATEGORY_COL_IS_INCOME} = $isIncome"
+                "SELECT * FROM (SELECT * FROM ${DatabaseHelper.TABLE_ACCOUNT_BOOK} WHERE ${DatabaseHelper.ACCOUNT_BOOK_COL_MONTH} = $month ORDER BY ${DatabaseHelper.ACCOUNT_BOOK_COL_MONTH} DESC) as T, ${DatabaseHelper.TABLE_CATEGORY}, ${DatabaseHelper.TABLE_PAYMENT} WHERE T.${DatabaseHelper.ACCOUNT_BOOK_COL_CATEGORY} = ${DatabaseHelper.TABLE_CATEGORY}.${DatabaseHelper.CATEGORY_COL_ID} AND T.${DatabaseHelper.ACCOUNT_BOOK_COL_PAYMENT} = ${DatabaseHelper.TABLE_PAYMENT}.${DatabaseHelper.PAYMENT_COL_ID} AND ${DatabaseHelper.TABLE_CATEGORY}.${DatabaseHelper.CATEGORY_COL_IS_INCOME} = $isIncome"
             val cursor = database.rawQuery(sql, null)
             return cursor.use {
                 while (it.moveToNext()) {

--- a/app/src/main/java/com/woowa/accountbook/ui/AccountBookApp.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/AccountBookApp.kt
@@ -5,13 +5,16 @@ import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
+import com.woowa.accountbook.ui.calendar.CalendarViewModel
 import com.woowa.accountbook.ui.calendar.component.CalendarScreen
 import com.woowa.accountbook.ui.component.AccountBookFloatingButton
+import com.woowa.accountbook.ui.history.HistoryViewModel
 import com.woowa.accountbook.ui.history.component.HistoryScreen
 import com.woowa.accountbook.ui.history.component.RegistrationScreen
 import com.woowa.accountbook.ui.iconpack.IconPack
@@ -47,6 +50,10 @@ fun AccountBookApp() {
             },
             scaffoldState = appState.scaffoldState
         ) { innerPaddingModifier ->
+
+            val historyViewModel: HistoryViewModel = hiltViewModel()
+            val calendarViewModel: CalendarViewModel = hiltViewModel()
+
             NavHost(
                 navController = appState.navController,
                 startDestination = Destinations.HOME,
@@ -54,7 +61,9 @@ fun AccountBookApp() {
             ) {
                 accountBookNavGraph(
                     navController = appState.navController,
-                    navigationUp = { appState.navigateUp() }
+                    navigationUp = { appState.navigateUp() },
+                    historyViewModel = historyViewModel,
+                    calendarViewModel = calendarViewModel
                 )
             }
         }
@@ -98,13 +107,15 @@ fun selectNavigation(currentRoute: String, section: HomeSections): Boolean {
 
 private fun NavGraphBuilder.accountBookNavGraph(
     navController: NavController,
-    navigationUp: () -> Unit
+    navigationUp: () -> Unit,
+    historyViewModel: HistoryViewModel,
+    calendarViewModel: CalendarViewModel
 ) {
     navigation(
         route = Destinations.HOME,
         startDestination = HomeSections.HISTORY.route
     ) {
-        addHomeGraph()
+        addHomeGraph(historyViewModel, calendarViewModel)
     }
     composable(route = Destinations.REGISTRATION) {
         RegistrationScreen()
@@ -114,15 +125,18 @@ private fun NavGraphBuilder.accountBookNavGraph(
     }
 }
 
-private fun NavGraphBuilder.addHomeGraph() {
+private fun NavGraphBuilder.addHomeGraph(
+    historyViewModel: HistoryViewModel,
+    calendarViewModel: CalendarViewModel
+) {
     composable(HomeSections.HISTORY.route) {
-        HistoryScreen()
+        HistoryScreen(historyViewModel, calendarViewModel)
     }
     composable(HomeSections.CALENDAR.route) {
         CalendarScreen()
     }
     composable(HomeSections.STATISTICS.route) {
-        StatisticsScreen()
+        StatisticsScreen(historyViewModel, calendarViewModel)
     }
     composable(HomeSections.SETTING.route) {
         SettingScreen()

--- a/app/src/main/java/com/woowa/accountbook/ui/component/Text.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/component/Text.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.woowa.accountbook.ui.theme.Green2
@@ -27,9 +28,12 @@ fun LabelText(
         Modifier
             .clip(RoundedCornerShape(50.dp))
             .background(color)
+            .width(58.dp)
             .padding(vertical = 4.dp, horizontal = 8.dp)
     ) {
         Text(
+            modifier = Modifier.fillMaxWidth(),
+            textAlign = TextAlign.Center,
             text = text,
             style = textStyle,
             color = White

--- a/app/src/main/java/com/woowa/accountbook/ui/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/history/HistoryViewModel.kt
@@ -39,6 +39,11 @@ class HistoryViewModel @Inject constructor(private val historyRepository: Histor
         _history.value = emptyList()
     }
 
+    fun getHistoryMonthAndType(month: Int, type: Boolean) {
+        val result = historyRepository.getHistoriesMonthAndType(month, type).getOrThrow()
+        _history.value = result
+    }
+
     fun resetCheckedHistory() {
         _history.value = _history.value.map {
             it.copy(isChecked = false)

--- a/app/src/main/java/com/woowa/accountbook/ui/history/component/HistoryScreen.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/history/component/HistoryScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -32,8 +33,8 @@ fun HistoryScreen(
     historyViewModel: HistoryViewModel = hiltViewModel(),
     calendarViewModel: CalendarViewModel = hiltViewModel()
 ) {
-    val inComeIsChecked = remember { mutableStateOf(true) }
-    val expenseIsChecked = remember { mutableStateOf(false) }
+    val inComeIsChecked = rememberSaveable { mutableStateOf(true) }
+    val expenseIsChecked = rememberSaveable { mutableStateOf(false) }
     val editMode = remember { mutableStateOf(false) }
     val yearAndMonth = calendarViewModel.yearAndMonth.collectAsState().value
     val (year, month) = calendarViewModel.yearMonthPair.value

--- a/app/src/main/java/com/woowa/accountbook/ui/statistics/component/StatisticsScreen.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/statistics/component/StatisticsScreen.kt
@@ -1,9 +1,262 @@
 package com.woowa.accountbook.ui.statistics.component
 
+import android.view.ViewGroup.LayoutParams.MATCH_PARENT
+import android.widget.LinearLayout
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.github.mikephil.charting.animation.Easing
+import com.github.mikephil.charting.charts.PieChart
+import com.github.mikephil.charting.data.PieData
+import com.github.mikephil.charting.data.PieDataSet
+import com.github.mikephil.charting.data.PieEntry
+import com.woowa.accountbook.common.rawToMoneyFormat
+import com.woowa.accountbook.data.entitiy.History
+import com.woowa.accountbook.ui.calendar.CalendarViewModel
+import com.woowa.accountbook.ui.component.*
+import com.woowa.accountbook.ui.history.HistoryViewModel
+import com.woowa.accountbook.ui.iconpack.IconPack
+import com.woowa.accountbook.ui.iconpack.LeftArrow
+import com.woowa.accountbook.ui.iconpack.RightArrow
+import com.woowa.accountbook.ui.theme.*
+import kotlin.math.round
 
 @Composable
-fun StatisticsScreen() {
-    Text(text = "통계 화면")
+fun StatisticsScreen(
+    historyViewModel: HistoryViewModel = hiltViewModel(),
+    calendarViewModel: CalendarViewModel = hiltViewModel()
+) {
+    val yearAndMonth = calendarViewModel.yearAndMonth.collectAsState().value
+    val (year, month) = calendarViewModel.yearMonthPair.value
+    historyViewModel.getHistoryMonthAndType(month, false)
+    val histories = historyViewModel.history.collectAsState().value
+    val groupBy = histories.groupBy { Pair(it.category.name, it.category.color) }
+    val totalExpense = histories.sumOf { it.money }
+
+    Scaffold(
+        backgroundColor = OffWhite,
+        topBar = {
+            AccountBookAppBar(
+                title = yearAndMonth,
+                navigationIcon = IconPack.LeftArrow,
+                onNavigationClicked = {
+                    calendarViewModel.previousYearAndMonth()
+                },
+                actionIcon = IconPack.RightArrow,
+                onActionClicked = {
+                    calendarViewModel.nextYearAndMonth()
+                },
+                dialog = { isShow, onDismissRequest ->
+                    AccountBookDialog(
+                        isShow = isShow,
+                        onDismissRequest = { onDismissRequest(it) },
+                        modifier = Modifier
+                            .fillMaxWidth(),
+                        content = {
+                            YearAndMonthPicker(
+                                year,
+                                month,
+                                onClicked = { year, month ->
+                                    onDismissRequest(it)
+                                    calendarViewModel.setYearAndMonth(year, month)
+                                }
+                            )
+                        }
+                    )
+                }
+            )
+        }
+    ) {
+        if (histories.isEmpty()) {
+            Text(
+                modifier = Modifier
+                    .fillMaxSize(),
+                textAlign = TextAlign.Center,
+                style = Typography.subtitle1,
+                color = LightPurple,
+                text = "내역이 없습니다."
+            )
+        } else {
+            val expenseCategoryList = groupBy.map {
+                val categorySum = it.value.fold(0) { sum, history -> sum + history.money }
+                Pair(it.key, categorySum)
+            }.sortedByDescending { it.second }
+            ExpenseCategory(totalExpense, groupBy, expenseCategoryList)
+        }
+    }
+}
+
+@Composable
+private fun ExpenseCategory(
+    totalExpense: Int,
+    groupBy: Map<Pair<String, String>, List<History>>,
+    expenseCategoryList: List<Pair<Pair<String, String>, Int>>
+) {
+    Column {
+        BothSideText(
+            leftText = {
+                Text(
+                    text = "이번 달 총 지출 금액",
+                    style = MaterialTheme.typography.subtitle2,
+                    color = Purple,
+                )
+            },
+            rightText = {
+                Text(
+                    text = rawToMoneyFormat(totalExpense, 1),
+                    style = MaterialTheme.typography.subtitle2,
+                    color = Red
+                )
+            }
+        )
+        Spacer(
+            modifier = Modifier
+                .height(1.dp)
+                .fillMaxWidth()
+                .background(LightPurple)
+        )
+        Spacer(modifier = Modifier.height(23.dp))
+        ExpenseGraph(groupBy, totalExpense)
+        GraphLegend(expenseCategoryList, totalExpense)
+    }
+}
+
+@Composable
+private fun GraphLegend(
+    expenseCategoryList: List<Pair<Pair<String, String>, Int>>,
+    totalExpense: Int
+) {
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 16.dp, end = 16.dp, top = 24.dp)
+    ) {
+        itemsIndexed(expenseCategoryList) { index: Int, category ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 9.dp),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Row {
+                    LabelText(
+                        text = category.first.first,
+                        textStyle = MaterialTheme.typography.caption,
+                        color = Color(android.graphics.Color.parseColor(category.first.second))
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = rawToMoneyFormat(category.second, 1),
+                        style = MaterialTheme.typography.body2,
+                        color = Purple
+                    )
+                }
+                Spacer(modifier = Modifier.width(10.dp))
+                Text(
+                    text = "${round(100 * category.second / totalExpense.toFloat())}%",
+                    style = MaterialTheme.typography.subtitle2,
+                    color = Purple
+                )
+            }
+            if (expenseCategoryList.size != (index + 1)) Divider(color = Purple40)
+        }
+        item {
+            Spacer(
+                modifier = Modifier
+                    .height(1.dp)
+                    .fillMaxWidth()
+                    .background(LightPurple)
+            )
+        }
+    }
+}
+
+@Composable
+private fun ExpenseGraph(
+    groupBy: Map<Pair<String, String>, List<History>>,
+    totalExpense: Int,
+) {
+    AndroidView(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(500.dp),
+        factory = { context ->
+
+            val pieChart = PieChart(context)
+            pieChart.layoutParams = LinearLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT)
+            pieChart.description.isEnabled = false
+            pieChart.legend.isEnabled = false
+            pieChart.isRotationEnabled = false
+            pieChart.transparentCircleRadius = 0f
+            pieChart.setTouchEnabled(false)
+            pieChart.setHoleColor(0)
+
+
+            val noOfEmp = mutableListOf<PieEntry>()
+            groupBy.forEach { (key, value) ->
+                val fold = value.fold(0) { sum, history -> sum + history.money }
+                noOfEmp.add(
+                    PieEntry(
+                        fold.toFloat(),
+                        round(100 * fold / totalExpense.toFloat())
+                    )
+                )
+            }
+            noOfEmp.sortByDescending { it.value }
+
+            val dataSet = PieDataSet(noOfEmp, "Expense")
+            dataSet.setDrawValues(false)
+            val pieData = PieData(dataSet)
+            val categoryColorList = groupBy.map { (key, value) ->
+                android.graphics.Color.parseColor(key.second)
+            }
+            dataSet.colors = categoryColorList
+            pieChart.data = pieData
+            pieChart.animateY(1000, Easing.EaseInBack)
+
+            pieChart
+        },
+        update = { pieChart ->
+            val noOfEmp = mutableListOf<PieEntry>()
+            groupBy.forEach { (key, value) ->
+                val fold = value.fold(0) { sum, history -> sum + history.money }
+                noOfEmp.add(
+                    PieEntry(
+                        fold.toFloat(),
+                        round(100 * fold / totalExpense.toFloat())
+                    )
+                )
+            }
+            noOfEmp.sortByDescending { it.value }
+
+            val dataSet = PieDataSet(noOfEmp, "Expense")
+            dataSet.setDrawValues(false)
+            val pieData = PieData(dataSet)
+            val categoryColorList = groupBy.map { (key, value) ->
+                android.graphics.Color.parseColor(key.second)
+            }
+            dataSet.colors = categoryColorList
+            pieChart.data = pieData
+        }
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun StatisticsScreenPreview() {
+    StatisticsScreen()
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,6 +10,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
 }
 rootProject.name = "AccountBook"


### PR DESCRIPTION
### Issue

- closed #32 

### Description

- LabelText 컴포넌트 fillMaxWidth() 추가
  - 통계 화면에서는 한 Row에 배치해야하기 때문에 fillMaxWidth 추가

- MPChart을 통해 pieChart 생성
  - Compose을 지원하지 않아서 AndroidView을 통해 처리

- 월 별 지출 내역 추가
  - 내역화면에서 작성했던 정보가 필요하기 때문에 뷰모델 공유
  - 통계에서는 지출내역만 다루기 때문에, 지출내역을 조회하는 메서드 생성
    - 지출내역을 조회하는 쿼리문에서 월 별에 따른 조회가 아니였기 때문에 월별 조회를 위해 WHERE 문에 추가
