### PR TITLE
달력 화면 구성하기

### DIFF
--- a/app/src/main/java/com/woowa/accountbook/common/Constants.kt
+++ b/app/src/main/java/com/woowa/accountbook/common/Constants.kt
@@ -4,3 +4,4 @@ import java.util.*
 
 val NOW_YEAR = Calendar.getInstance().get(Calendar.YEAR)
 val NOW_MONTH = Calendar.getInstance().get(Calendar.MONTH) + 1
+val NOW_DAY = Calendar.getInstance().get(Calendar.DATE)

--- a/app/src/main/java/com/woowa/accountbook/domain/entity/DateItem.kt
+++ b/app/src/main/java/com/woowa/accountbook/domain/entity/DateItem.kt
@@ -1,0 +1,12 @@
+package com.woowa.accountbook.domain.entity
+
+import androidx.compose.ui.graphics.Color
+
+data class DateItem(
+    val expense: Int?,
+    val income: Int?,
+    val year: Int,
+    val month: Int,
+    val date: Int,
+    val color: Color
+)

--- a/app/src/main/java/com/woowa/accountbook/ui/AccountBookApp.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/AccountBookApp.kt
@@ -133,7 +133,7 @@ private fun NavGraphBuilder.addHomeGraph(
         HistoryScreen(historyViewModel, calendarViewModel)
     }
     composable(HomeSections.CALENDAR.route) {
-        CalendarScreen()
+        CalendarScreen(historyViewModel, calendarViewModel)
     }
     composable(HomeSections.STATISTICS.route) {
         StatisticsScreen(historyViewModel, calendarViewModel)

--- a/app/src/main/java/com/woowa/accountbook/ui/calendar/CalendarViewModel.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/calendar/CalendarViewModel.kt
@@ -1,6 +1,10 @@
 package com.woowa.accountbook.ui.calendar
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
+import com.woowa.accountbook.common.NOW_DAY
+import com.woowa.accountbook.common.NOW_MONTH
+import com.woowa.accountbook.common.NOW_YEAR
 import com.woowa.accountbook.data.entitiy.History
 import com.woowa.accountbook.domain.entity.DateItem
 import com.woowa.accountbook.ui.theme.LightPurple
@@ -21,6 +25,14 @@ class CalendarViewModel @Inject constructor(private val calendar: CustomCalendar
 
     private val _dateList = MutableStateFlow<List<DateItem>>(emptyList())
     val dateList: StateFlow<List<DateItem>> get() = _dateList
+
+    private val _selectedDate = MutableStateFlow<DateItem?>(null)
+    val selectedDate: StateFlow<DateItem?> get() = _selectedDate
+
+    fun selectedDate(dateItem: DateItem) {
+        _selectedDate.value = dateItem
+        Log.d("test", "selectedDate: ${selectedDate.value?.date}")
+    }
 
     fun setYearAndMonth(year: Int, month: Int) {
         _yearAndMonth.value = calendar.setYearAndMonth(year, month)
@@ -81,5 +93,9 @@ class CalendarViewModel @Inject constructor(private val calendar: CustomCalendar
                 _dateList.value = dateItems
             }
         }
+    }
+
+    fun isToday(dateItem: DateItem): Boolean {
+        return dateItem.year == NOW_YEAR && dateItem.month == NOW_MONTH && dateItem.date == NOW_DAY
     }
 }

--- a/app/src/main/java/com/woowa/accountbook/ui/calendar/CalendarViewModel.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/calendar/CalendarViewModel.kt
@@ -1,6 +1,10 @@
 package com.woowa.accountbook.ui.calendar
 
 import androidx.lifecycle.ViewModel
+import com.woowa.accountbook.data.entitiy.History
+import com.woowa.accountbook.domain.entity.DateItem
+import com.woowa.accountbook.ui.theme.LightPurple
+import com.woowa.accountbook.ui.theme.Purple
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -15,6 +19,9 @@ class CalendarViewModel @Inject constructor(private val calendar: CustomCalendar
     private val _yearMonthPair = MutableStateFlow(calendar.yearMonthPair)
     val yearMonthPair: StateFlow<Pair<Int, Int>> get() = _yearMonthPair
 
+    private val _dateList = MutableStateFlow<List<DateItem>>(emptyList())
+    val dateList: StateFlow<List<DateItem>> get() = _dateList
+
     fun setYearAndMonth(year: Int, month: Int) {
         _yearAndMonth.value = calendar.setYearAndMonth(year, month)
         _yearMonthPair.value = calendar.yearMonthPair
@@ -28,5 +35,51 @@ class CalendarViewModel @Inject constructor(private val calendar: CustomCalendar
     fun nextYearAndMonth() {
         _yearAndMonth.value = calendar.nextYearAndMonth()
         _yearMonthPair.value = calendar.yearMonthPair
+    }
+
+    fun getAllDate(histories: List<History>) {
+        val dateItems = mutableListOf<DateItem>()
+        calendar.dateList.forEachIndexed { index, pair ->
+            if (pair.first < 0) {
+                dateItems.add(DateItem(null, null, 0, 0, pair.second, LightPurple))
+            } else if (pair.first > 0) {
+                dateItems.add(DateItem(null, null, 0, 0, pair.second, LightPurple))
+            } else {
+                val groupHistory = histories.groupBy { it.day }
+                val dayList = groupHistory[pair.second]
+
+                if (dayList == null) {
+                    dateItems.add(
+                        DateItem(
+                            expense = null,
+                            income = null,
+                            year = _yearMonthPair.value.first,
+                            month = _yearMonthPair.value.second,
+                            date = pair.second,
+                            color = Purple
+                        )
+                    )
+                } else {
+                    val income = dayList
+                        .filter { it.category.isIncome == 1 }
+                        .sumOf { it.money }
+                    val expense = dayList
+                        .filter { it.category.isIncome == 0 }
+                        .sumOf { it.money }
+
+                    dateItems.add(
+                        DateItem(
+                            expense = expense,
+                            income = income,
+                            year = _yearMonthPair.value.first,
+                            month = _yearMonthPair.value.second,
+                            date = pair.second,
+                            color = Purple
+                        )
+                    )
+                }
+                _dateList.value = dateItems
+            }
+        }
     }
 }

--- a/app/src/main/java/com/woowa/accountbook/ui/calendar/CustomCalendar.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/calendar/CustomCalendar.kt
@@ -12,16 +12,29 @@ class CustomCalendar {
     val currentYearAndMonth = "${NOW_YEAR}년 ${NOW_MONTH}월"
     var yearMonthPair = Pair(NOW_YEAR, NOW_MONTH)
 
+    var currentMaxDate = 0
+    private var previousMonthOffset = 0
+    var nextMonthOffset = 0
+
+    private val _dateList = mutableListOf<Pair<Int, Int>>()
+    val dateList: List<Pair<Int, Int>> get() = _dateList
+
+    init {
+        getMonthDate(calendar)
+    }
+
     fun setYearAndMonth(year: Int, month: Int): String {
         calendar.set(Calendar.YEAR, year)
         calendar.set(Calendar.MONTH, month - 1)
         yearMonthPair = Pair(year, month)
+        getMonthDate(calendar.clone() as Calendar)
         return rawToYearAndMonth(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH) + 1)
     }
 
     fun previousYearAndMonth(): String {
         val year = calendar.get(Calendar.YEAR)
         val month = calendar.get(Calendar.MONTH)
+        calendar.set(Calendar.DATE, 1)
 
         if (month == 0) {
             calendar.set(Calendar.YEAR, year - 1)
@@ -30,6 +43,7 @@ class CustomCalendar {
             calendar.set(Calendar.MONTH, month - 1)
         }
         yearMonthPair = Pair(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH) + 1)
+        getMonthDate(calendar.clone() as Calendar)
         return rawToYearAndMonth(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH) + 1)
     }
 
@@ -44,8 +58,43 @@ class CustomCalendar {
             calendar.set(Calendar.MONTH, month + 1)
         }
         yearMonthPair = Pair(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH) + 1)
+        getMonthDate(calendar.clone() as Calendar)
         return rawToYearAndMonth(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH) + 1)
     }
 
+    private fun getMonthDate(calendar: Calendar) {
+        _dateList.clear()
 
+        calendar.set(Calendar.DATE, 1)
+        currentMaxDate = calendar.getActualMaximum(Calendar.DATE)
+        previousMonthOffset = calendar.get(Calendar.DAY_OF_WEEK) - 1
+        getPreviousMonthOffsetDate(calendar.clone() as Calendar)
+
+        getCurrentMonthDate(calendar)
+
+        calendar.set(Calendar.DATE, currentMaxDate)
+        nextMonthOffset = calendar.get(Calendar.DAY_OF_WEEK)
+        getNextMonthOffsetDate()
+    }
+
+    private fun getNextMonthOffsetDate() {
+        var nextDate = 0
+        repeat(Calendar.DAY_OF_WEEK - nextMonthOffset) {
+            _dateList.add(1 to ++nextDate)
+        }
+    }
+
+    private fun getPreviousMonthOffsetDate(calendar: Calendar) {
+        calendar.set(Calendar.MONTH, calendar.get(Calendar.MONTH) - 1)
+        var previousMaxDate = calendar.getActualMaximum(Calendar.DATE) - previousMonthOffset
+        repeat(previousMonthOffset) {
+            _dateList.add(-1 to ++previousMaxDate)
+        }
+    }
+
+    private fun getCurrentMonthDate(calendar: Calendar) {
+        repeat(calendar.getActualMaximum(Calendar.DATE)) {
+            _dateList.add(0 to it + 1)
+        }
+    }
 }

--- a/app/src/main/java/com/woowa/accountbook/ui/calendar/component/CalendarScreen.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/calendar/component/CalendarScreen.kt
@@ -1,9 +1,228 @@
 package com.woowa.accountbook.ui.calendar.component
 
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.GridCells
+import androidx.compose.foundation.lazy.LazyVerticalGrid
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.woowa.accountbook.common.rawToMoneyFormat
+import com.woowa.accountbook.domain.entity.DateItem
+import com.woowa.accountbook.ui.calendar.CalendarViewModel
+import com.woowa.accountbook.ui.component.AccountBookAppBar
+import com.woowa.accountbook.ui.component.AccountBookDialog
+import com.woowa.accountbook.ui.component.BothSideText
+import com.woowa.accountbook.ui.component.YearAndMonthPicker
+import com.woowa.accountbook.ui.history.HistoryViewModel
+import com.woowa.accountbook.ui.iconpack.IconPack
+import com.woowa.accountbook.ui.iconpack.LeftArrow
+import com.woowa.accountbook.ui.iconpack.RightArrow
+import com.woowa.accountbook.ui.theme.*
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun CalendarScreen(
+    historyViewModel: HistoryViewModel = hiltViewModel(),
+    calendarViewModel: CalendarViewModel = hiltViewModel()
+) {
+    val yearAndMonth = calendarViewModel.yearAndMonth.collectAsState().value
+    val (year, month) = calendarViewModel.yearMonthPair.value
+    historyViewModel.initHistory(month)
+    val histories = historyViewModel.totalHistory.collectAsState()
+    calendarViewModel.getAllDate(histories.value)
+    val dateList = calendarViewModel.dateList.collectAsState().value
+
+    Scaffold(
+        backgroundColor = OffWhite,
+        topBar = {
+            AccountBookAppBar(
+                title = yearAndMonth,
+                navigationIcon = IconPack.LeftArrow,
+                onNavigationClicked = {
+                    calendarViewModel.previousYearAndMonth()
+                },
+                actionIcon = IconPack.RightArrow,
+                onActionClicked = {
+                    calendarViewModel.nextYearAndMonth()
+                },
+                dialog = { isShow, onDismissRequest ->
+                    AccountBookDialog(
+                        isShow = isShow,
+                        onDismissRequest = { onDismissRequest(it) },
+                        modifier = Modifier
+                            .fillMaxWidth(),
+                        content = {
+                            YearAndMonthPicker(
+                                year,
+                                month,
+                                onClicked = { year, month ->
+                                    onDismissRequest(it)
+                                    calendarViewModel.setYearAndMonth(year, month)
+                                }
+                            )
+                        }
+                    )
+                }
+            )
+        }
+    ) {
+        Column {
+            HistoryCalendar(dateList)
+            Spacer(modifier = Modifier.height(16.dp))
+            val totalViewModel = historyViewModel.totalHistory.collectAsState().value
+            val monthTotalIncome =
+                totalViewModel.filter { it.category.isIncome == 1 }.sumOf { it.money }
+            val monthTotalExpense =
+                totalViewModel.filter { it.category.isIncome == 0 }.sumOf { it.money }
+            val totalIncome = rawToMoneyFormat(monthTotalIncome, 1)
+            val totalExpense = rawToMoneyFormat(monthTotalExpense, 0)
+            val total = rawToMoneyFormat(monthTotalExpense + (-monthTotalIncome), 1)
+            MonthIncomeAndExpense(totalIncome, totalExpense, total)
+        }
+    }
+
+}
 
 @Composable
-fun CalendarScreen() {
-    Text(text = "달력 화면")
+private fun MonthIncomeAndExpense(
+    totalIncome: String,
+    totalExpense: String,
+    total: String
+) {
+    BothSideText(
+        leftText = {
+            Text(
+                text = "수입",
+                style = MaterialTheme.typography.subtitle2,
+                color = Purple,
+            )
+        },
+        rightText = {
+            Text(
+                text = if (totalIncome != "") totalIncome else "0",
+                style = MaterialTheme.typography.subtitle2,
+                color = Green3
+            )
+        }
+    )
+    Divider(modifier = Modifier.padding(horizontal = 16.dp), color = Purple40)
+    BothSideText(
+        leftText = {
+            Text(
+                text = "지출",
+                style = MaterialTheme.typography.subtitle2,
+                color = Purple,
+            )
+        },
+        rightText = {
+            Text(
+                text = if (totalExpense != "") totalExpense else "0",
+                style = MaterialTheme.typography.subtitle2,
+                color = Red
+            )
+        }
+    )
+    Divider(modifier = Modifier.padding(horizontal = 16.dp), color = Purple40)
+    BothSideText(
+        leftText = {
+            Text(
+                text = "총합",
+                style = MaterialTheme.typography.subtitle2,
+                color = Purple,
+            )
+        },
+        rightText = {
+            Text(
+                text = if (total != "") total else "0",
+                style = MaterialTheme.typography.subtitle2,
+                color = Purple
+            )
+        }
+    )
+    Spacer(
+        modifier = Modifier
+            .height(1.dp)
+            .fillMaxWidth()
+            .background(LightPurple)
+    )
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun HistoryCalendar(dateList: List<DateItem>) {
+    LazyVerticalGrid(
+        modifier = Modifier.fillMaxWidth(),
+        cells = GridCells.Fixed(count = 7)
+    ) {
+        itemsIndexed(dateList) { idx, dateItem ->
+            CalendarItem(dateItem)
+        }
+    }
+}
+
+
+@Composable
+fun CalendarItem(dateItem: DateItem) {
+    Column(
+        modifier = Modifier
+            .height(100.dp)
+            .border(
+                width = 0.5.dp,
+                color = LightPurple,
+                shape = RectangleShape
+            )
+            .padding(4.dp),
+        verticalArrangement = Arrangement.SpaceBetween
+    ) {
+        val income = dateItem.income ?: 0
+        val expense = dateItem.expense ?: 0
+        Column {
+            if (income != 0) {
+                Text(
+                    text = rawToMoneyFormat(income, 1),
+                    color = Green3,
+                    style = MaterialTheme.typography.caption
+                )
+            }
+            if (expense != 0) {
+                Text(
+                    text = rawToMoneyFormat(expense, 0),
+                    color = Red,
+                    style = MaterialTheme.typography.caption
+                )
+            }
+            Text(
+                text = rawToMoneyFormat(income - expense, 1),
+                color = LightPurple,
+                style = MaterialTheme.typography.caption
+            )
+        }
+        Text(
+            modifier = Modifier
+                .fillMaxWidth(),
+            text = dateItem.date.toString(),
+            textAlign = TextAlign.End,
+            color = dateItem.color,
+            style = MaterialTheme.typography.caption
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun CalendarScreenPreview() {
+    CalendarScreen()
 }

--- a/app/src/main/java/com/woowa/accountbook/ui/calendar/component/CalendarScreen.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/calendar/component/CalendarScreen.kt
@@ -3,6 +3,8 @@ package com.woowa.accountbook.ui.calendar.component
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.GridCells
 import androidx.compose.foundation.lazy.LazyVerticalGrid
@@ -13,7 +15,9 @@ import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -80,7 +84,13 @@ fun CalendarScreen(
         }
     ) {
         Column {
-            HistoryCalendar(dateList)
+            val selectedDate = calendarViewModel.selectedDate.collectAsState().value
+            HistoryCalendar(
+                dateList = dateList,
+                onCheckToday = { if (calendarViewModel.isToday(it)) White else OffWhite },
+                onClicked = { calendarViewModel.selectedDate(it) },
+                selectedDate = selectedDate
+            )
             Spacer(modifier = Modifier.height(16.dp))
             val totalViewModel = historyViewModel.totalHistory.collectAsState().value
             val monthTotalIncome =
@@ -162,29 +172,53 @@ private fun MonthIncomeAndExpense(
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-private fun HistoryCalendar(dateList: List<DateItem>) {
+private fun HistoryCalendar(
+    dateList: List<DateItem>,
+    onCheckToday: (DateItem) -> Color,
+    onClicked: (DateItem) -> Unit,
+    selectedDate: DateItem?
+) {
     LazyVerticalGrid(
         modifier = Modifier.fillMaxWidth(),
         cells = GridCells.Fixed(count = 7)
     ) {
-        itemsIndexed(dateList) { idx, dateItem ->
-            CalendarItem(dateItem)
+        itemsIndexed(dateList) { _, dateItem ->
+            CalendarItem(
+                dateItem = dateItem,
+                onCheckToday = { onCheckToday(it) },
+                onClicked = { onClicked(it) },
+                selectedDate = selectedDate
+            )
         }
     }
 }
 
 
 @Composable
-fun CalendarItem(dateItem: DateItem) {
+fun CalendarItem(
+    dateItem: DateItem,
+    onCheckToday: (DateItem) -> Color,
+    onClicked: (DateItem) -> Unit,
+    selectedDate: DateItem?
+) {
+    var color = onCheckToday(dateItem)
+    if (selectedDate == dateItem) color = Purple40
+
     Column(
         modifier = Modifier
             .height(100.dp)
+            .background(color)
             .border(
                 width = 0.5.dp,
                 color = LightPurple,
                 shape = RectangleShape
             )
-            .padding(4.dp),
+            .padding(4.dp)
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                onClick = { onClicked(dateItem) },
+                indication = null
+            ),
         verticalArrangement = Arrangement.SpaceBetween
     ) {
         val income = dateItem.income ?: 0


### PR DESCRIPTION
### Issue

- closed #34 

### Description

- 달력 데이터 공유
  - CalendarViewModel, HistoryViewModel 공유

- 달력 해당 월 일 구하기
  - 해당 월의 일수 리스트 구하기

- 달력에 뿌려질 데이터 생성
  - 지출, 수입, 년, 월, 일, 색상 관리 데이터 생성(DateItem)

- 현재 날짜 배경색 흰색으로 설정

- 선택한 날짜 배경색 연한 보라색으로 설정
  - 사용자에게 자유롭게 보여주기 위해서 ripple 제거