### PR TITLE
내역 추가 기능 구현하기

### DIFF
--- a/app/src/main/java/com/woowa/accountbook/common/TextFormat.kt
+++ b/app/src/main/java/com/woowa/accountbook/common/TextFormat.kt
@@ -2,11 +2,15 @@ package com.woowa.accountbook.common
 
 import java.text.DecimalFormat
 
-fun rawToMoneyFormat(money: Int, isIncome: Int): String {
+fun rawToMoneyFormat(money: Int, isIncome: Int?): String {
     if (money == 0) return ""
-    val decimalFormat = DecimalFormat("#,###")
-    val result = decimalFormat.format(money)
+    val result = stringToMoneyFormat(money)
     return if (isIncome == 1) result else "-$result"
+}
+
+fun stringToMoneyFormat(money: Int): String {
+    val decimalFormat = DecimalFormat("#,###")
+    return decimalFormat.format(money)
 }
 
 fun rawToYearAndMonth(year: Int, month: Int): String {

--- a/app/src/main/java/com/woowa/accountbook/data/entitiy/Category.kt
+++ b/app/src/main/java/com/woowa/accountbook/data/entitiy/Category.kt
@@ -1,8 +1,8 @@
 package com.woowa.accountbook.data.entitiy
 
 data class Category(
-    val id: Int,
-    val isIncome: Int,
-    val name: String,
-    val color: String
+    val id: Int?,
+    val isIncome: Int?,
+    val name: String?,
+    val color: String?
 )

--- a/app/src/main/java/com/woowa/accountbook/data/entitiy/History.kt
+++ b/app/src/main/java/com/woowa/accountbook/data/entitiy/History.kt
@@ -7,7 +7,7 @@ data class History(
     val year: Int,
     val month: Int,
     val day: Int,
-    val category: Category,
+    val category: Category?,
     val payment: Payment,
     var isChecked: Boolean = false
 )

--- a/app/src/main/java/com/woowa/accountbook/data/local/Sql.kt
+++ b/app/src/main/java/com/woowa/accountbook/data/local/Sql.kt
@@ -20,7 +20,7 @@ internal val createAccountBookQuery = """
             CREATE TABLE ${DatabaseHelper.TABLE_ACCOUNT_BOOK} (
                 ${DatabaseHelper.ACCOUNT_BOOK_COL_ID} INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
                 ${DatabaseHelper.ACCOUNT_BOOK_COL_MONEY} INTEGER NOT NULL,
-                ${DatabaseHelper.ACCOUNT_BOOK_COL_CATEGORY} INTEGER NOT NULL,
+                ${DatabaseHelper.ACCOUNT_BOOK_COL_CATEGORY} INTEGER,
                 ${DatabaseHelper.ACCOUNT_BOOK_COL_PAYMENT} INTEGER NOT NULL, 
                 ${DatabaseHelper.ACCOUNT_BOOK_COL_CONTENT} TEXT,
                 ${DatabaseHelper.ACCOUNT_BOOK_COL_YEAR} INTEGER NOT NULL,

--- a/app/src/main/java/com/woowa/accountbook/data/local/category/CategoryDataSource.kt
+++ b/app/src/main/java/com/woowa/accountbook/data/local/category/CategoryDataSource.kt
@@ -4,6 +4,8 @@ import com.woowa.accountbook.data.entitiy.Category
 
 interface CategoryDataSource {
 
+    fun findById(id: Int): Category?
+    fun findByName(name: String): Category?
     fun findByType(type: String): List<Category>
     fun deleteById(list: List<Int>)
     fun save(name: String, color: String, isIncome: Boolean)

--- a/app/src/main/java/com/woowa/accountbook/data/local/category/CategoryLocalDataSource.kt
+++ b/app/src/main/java/com/woowa/accountbook/data/local/category/CategoryLocalDataSource.kt
@@ -9,6 +9,42 @@ class CategoryLocalDataSource @Inject constructor(
     private val databaseHelper: DatabaseHelper
 ) : CategoryDataSource {
 
+    override fun findById(id: Int): Category? {
+        databaseHelper.readableDatabase.use { database ->
+            val sql =
+                "SELECT * FROM ${DatabaseHelper.TABLE_CATEGORY} WHERE ${DatabaseHelper.CATEGORY_COL_ID} = ?"
+            val cursor = database.rawQuery(sql, arrayOf(id.toString()))
+            return cursor.use {
+                if (it.moveToNext()) {
+                    Category(
+                        id = it.getInt(0),
+                        isIncome = it.getInt(1),
+                        name = it.getString(2),
+                        color = it.getString(3)
+                    )
+                } else null
+            }
+        }
+    }
+
+    override fun findByName(name: String): Category? {
+        databaseHelper.readableDatabase.use { database ->
+            val sql =
+                "SELECT * FROM ${DatabaseHelper.TABLE_CATEGORY} WHERE ${DatabaseHelper.CATEGORY_COL_NAME} = ?"
+            val cursor = database.rawQuery(sql, arrayOf(name))
+            return cursor.use {
+                if (it.moveToNext()) {
+                    Category(
+                        id = it.getInt(0),
+                        isIncome = it.getInt(1),
+                        name = it.getString(2),
+                        color = it.getString(3)
+                    )
+                } else null
+            }
+        }
+    }
+
     override fun findByType(type: String): List<Category> {
         val categoryList = mutableListOf<Category>()
         databaseHelper.readableDatabase.use { database ->

--- a/app/src/main/java/com/woowa/accountbook/data/local/history/HistoryDataSource.kt
+++ b/app/src/main/java/com/woowa/accountbook/data/local/history/HistoryDataSource.kt
@@ -10,7 +10,7 @@ interface HistoryDataSource {
     fun deleteById(list: List<Int>)
     fun save(
         money: Int,
-        categoryId: Int,
+        categoryId: Int?,
         content: String,
         year: Int,
         month: Int,

--- a/app/src/main/java/com/woowa/accountbook/data/local/history/HistoryLocalDataSource.kt
+++ b/app/src/main/java/com/woowa/accountbook/data/local/history/HistoryLocalDataSource.kt
@@ -41,7 +41,7 @@ class HistoryLocalDataSource @Inject constructor(
                         day = day,
                         Category(
                             id = categoryIdPK,
-                            isIncome = isIncome,
+                            isIncome = if (categoryIdPK == 0) 1 else isIncome,
                             name = categoryName,
                             color = color
                         ),
@@ -61,7 +61,7 @@ class HistoryLocalDataSource @Inject constructor(
         val historyList = mutableListOf<History>()
         databaseHelper.readableDatabase.use { database ->
             val sql =
-                "SELECT * FROM (SELECT * FROM ${DatabaseHelper.TABLE_ACCOUNT_BOOK} WHERE ${DatabaseHelper.ACCOUNT_BOOK_COL_MONTH} = $month ORDER BY ${DatabaseHelper.ACCOUNT_BOOK_COL_DAY} DESC) as T, ${DatabaseHelper.TABLE_CATEGORY}, ${DatabaseHelper.TABLE_PAYMENT} WHERE T.${DatabaseHelper.ACCOUNT_BOOK_COL_CATEGORY} = ${DatabaseHelper.TABLE_CATEGORY}.${DatabaseHelper.CATEGORY_COL_ID} AND T.${DatabaseHelper.ACCOUNT_BOOK_COL_PAYMENT} = ${DatabaseHelper.TABLE_PAYMENT}.${DatabaseHelper.PAYMENT_COL_ID}"
+                "SELECT * FROM (SELECT * FROM ${DatabaseHelper.TABLE_ACCOUNT_BOOK} WHERE ${DatabaseHelper.ACCOUNT_BOOK_COL_MONTH} = $month ORDER BY ${DatabaseHelper.ACCOUNT_BOOK_COL_DAY} DESC) as T LEFT JOIN ${DatabaseHelper.TABLE_CATEGORY} ON T.${DatabaseHelper.ACCOUNT_BOOK_COL_CATEGORY} = ${DatabaseHelper.TABLE_CATEGORY}.${DatabaseHelper.CATEGORY_COL_ID} LEFT JOIN ${DatabaseHelper.TABLE_PAYMENT} ON T.${DatabaseHelper.ACCOUNT_BOOK_COL_PAYMENT} = ${DatabaseHelper.TABLE_PAYMENT}.${DatabaseHelper.PAYMENT_COL_ID}"
             val cursor = database.rawQuery(sql, null)
             return cursor.use {
                 while (it.moveToNext()) {
@@ -77,7 +77,6 @@ class HistoryLocalDataSource @Inject constructor(
                     val color = it.getString(11)
                     val paymentIdPK = it.getInt(12)
                     val paymentName = it.getString(13)
-
                     val history = History(
                         id = id,
                         money = money,
@@ -87,7 +86,7 @@ class HistoryLocalDataSource @Inject constructor(
                         day = day,
                         Category(
                             id = categoryIdPK,
-                            isIncome = isIncome,
+                            isIncome = if (categoryIdPK == 0) 1 else isIncome,
                             name = categoryName,
                             color = color
                         ),
@@ -134,7 +133,7 @@ class HistoryLocalDataSource @Inject constructor(
                         day = day,
                         Category(
                             id = categoryIdPK,
-                            isIncome = isIncome,
+                            isIncome = if (categoryIdPK == 0) 1 else isIncome,
                             name = categoryName,
                             color = color
                         ),
@@ -160,7 +159,7 @@ class HistoryLocalDataSource @Inject constructor(
 
     override fun save(
         money: Int,
-        categoryId: Int,
+        categoryId: Int?,
         content: String,
         year: Int,
         month: Int,

--- a/app/src/main/java/com/woowa/accountbook/data/local/payment/PaymentDataSource.kt
+++ b/app/src/main/java/com/woowa/accountbook/data/local/payment/PaymentDataSource.kt
@@ -4,6 +4,8 @@ import com.woowa.accountbook.data.entitiy.Payment
 
 interface PaymentDataSource {
 
+    fun findById(id: Int): Payment?
+    fun findByName(name: String): Payment?
     fun findAll(): List<Payment>
     fun deleteById(list: List<Int>)
     fun save(name: String)

--- a/app/src/main/java/com/woowa/accountbook/data/local/payment/PaymentLocalDataSource.kt
+++ b/app/src/main/java/com/woowa/accountbook/data/local/payment/PaymentLocalDataSource.kt
@@ -9,6 +9,38 @@ class PaymentLocalDataSource @Inject constructor(
     private val databaseHelper: DatabaseHelper
 ) : PaymentDataSource {
 
+    override fun findById(id: Int): Payment? {
+        databaseHelper.readableDatabase.use { database ->
+            val sql =
+                "SELECT * FROM ${DatabaseHelper.TABLE_PAYMENT} WHERE ${DatabaseHelper.PAYMENT_COL_ID} = ?"
+            val cursor = database.rawQuery(sql, arrayOf(id.toString()))
+            return cursor.use {
+                if (it.moveToNext()) {
+                    Payment(
+                        id = it.getInt(0),
+                        name = it.getString(1)
+                    )
+                } else null
+            }
+        }
+    }
+
+    override fun findByName(name: String): Payment? {
+        databaseHelper.readableDatabase.use { database ->
+            val sql =
+                "SELECT * FROM ${DatabaseHelper.TABLE_PAYMENT} WHERE ${DatabaseHelper.PAYMENT_COL_NAME} = ?"
+            val cursor = database.rawQuery(sql, arrayOf(name))
+            return cursor.use {
+                if (it.moveToNext()) {
+                    Payment(
+                        id = it.getInt(0),
+                        name = it.getString(1)
+                    )
+                } else null
+            }
+        }
+    }
+
     override fun findAll(): List<Payment> {
         val paymentList = mutableListOf<Payment>()
         databaseHelper.readableDatabase.use { database ->

--- a/app/src/main/java/com/woowa/accountbook/data/repository/CategoryRepositoryImpl.kt
+++ b/app/src/main/java/com/woowa/accountbook/data/repository/CategoryRepositoryImpl.kt
@@ -10,7 +10,7 @@ class CategoryRepositoryImpl @Inject constructor(
 ) : CategoryRepository {
 
     override fun getCategoriesByType(type: String): Result<List<Category>> {
-        TODO("Not yet implemented")
+        return runCatching { categoryDataSource.findByType(type) }
     }
 
     override fun removeCategories(list: List<Int>) {
@@ -18,7 +18,11 @@ class CategoryRepositoryImpl @Inject constructor(
     }
 
     override fun saveCategory(name: String, color: String, isIncome: Boolean) {
-        TODO("Not yet implemented")
+        runCatching {
+            val category = categoryDataSource.findByName(name)
+            if (category == null)
+                categoryDataSource.save(name, color, isIncome)
+        }
     }
 
 }

--- a/app/src/main/java/com/woowa/accountbook/data/repository/HistoryRepositoryImpl.kt
+++ b/app/src/main/java/com/woowa/accountbook/data/repository/HistoryRepositoryImpl.kt
@@ -1,12 +1,16 @@
 package com.woowa.accountbook.data.repository
 
 import com.woowa.accountbook.data.entitiy.History
+import com.woowa.accountbook.data.local.category.CategoryDataSource
 import com.woowa.accountbook.data.local.history.HistoryDataSource
+import com.woowa.accountbook.data.local.payment.PaymentDataSource
 import com.woowa.accountbook.domain.repository.history.HistoryRepository
 import javax.inject.Inject
 
 class HistoryRepositoryImpl @Inject constructor(
-    private val historyDataSource: HistoryDataSource
+    private val historyDataSource: HistoryDataSource,
+    private val categoryDataSource: CategoryDataSource,
+    private val paymentDataSource: PaymentDataSource
 ) : HistoryRepository {
 
     override fun getHistories(): Result<List<History>> {
@@ -27,7 +31,7 @@ class HistoryRepositoryImpl @Inject constructor(
 
     override fun saveHistory(
         money: Int,
-        categoryId: Int,
+        categoryId: Int?,
         content: String,
         year: Int,
         month: Int,
@@ -35,6 +39,10 @@ class HistoryRepositoryImpl @Inject constructor(
         paymentId: Int
     ) {
         runCatching {
+            if (categoryId != null) {
+                val category = categoryDataSource.findById(categoryId) ?: return
+            }
+            val payment = paymentDataSource.findById(paymentId) ?: return
             historyDataSource.save(
                 money,
                 categoryId,

--- a/app/src/main/java/com/woowa/accountbook/data/repository/PaymentRepositoryImpl.kt
+++ b/app/src/main/java/com/woowa/accountbook/data/repository/PaymentRepositoryImpl.kt
@@ -10,7 +10,7 @@ class PaymentRepositoryImpl @Inject constructor(
 ) : PaymentRepository {
 
     override fun getPayments(): Result<List<Payment>> {
-        TODO("Not yet implemented")
+        return runCatching { paymentDataSource.findAll() }
     }
 
     override fun removePayments(list: List<Int>) {
@@ -18,6 +18,10 @@ class PaymentRepositoryImpl @Inject constructor(
     }
 
     override fun savePayment(name: String) {
-        TODO("Not yet implemented")
+        runCatching {
+            val payment = paymentDataSource.findByName(name)
+            if (payment == null)
+                paymentDataSource.save(name)
+        }
     }
 }

--- a/app/src/main/java/com/woowa/accountbook/di/RepositoryModule.kt
+++ b/app/src/main/java/com/woowa/accountbook/di/RepositoryModule.kt
@@ -21,8 +21,12 @@ object RepositoryModule {
 
     @Provides
     @Singleton
-    fun provideHistoryRepository(historyDataSource: HistoryDataSource): HistoryRepository {
-        return HistoryRepositoryImpl(historyDataSource)
+    fun provideHistoryRepository(
+        historyDataSource: HistoryDataSource,
+        categoryDataSource: CategoryDataSource,
+        paymentDataSource: PaymentDataSource
+    ): HistoryRepository {
+        return HistoryRepositoryImpl(historyDataSource, categoryDataSource, paymentDataSource)
     }
 
     @Provides

--- a/app/src/main/java/com/woowa/accountbook/domain/repository/history/HistoryRepository.kt
+++ b/app/src/main/java/com/woowa/accountbook/domain/repository/history/HistoryRepository.kt
@@ -9,7 +9,7 @@ interface HistoryRepository {
     fun removeHistories(list: List<Int>)
     fun saveHistory(
         money: Int,
-        categoryId: Int,
+        categoryId: Int?,
         content: String,
         year: Int,
         month: Int,

--- a/app/src/main/java/com/woowa/accountbook/ui/AccountBookApp.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/AccountBookApp.kt
@@ -118,7 +118,7 @@ private fun NavGraphBuilder.accountBookNavGraph(
         addHomeGraph(historyViewModel, calendarViewModel)
     }
     composable(route = Destinations.REGISTRATION) {
-        RegistrationScreen()
+        RegistrationScreen(historyViewModel, calendarViewModel, navigationUp = navigationUp)
     }
     composable(route = Destinations.STATISTICS_DETAIL) {
         StatisticsDetailScreen()

--- a/app/src/main/java/com/woowa/accountbook/ui/calendar/CalendarViewModel.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/calendar/CalendarViewModel.kt
@@ -73,10 +73,10 @@ class CalendarViewModel @Inject constructor(private val calendar: CustomCalendar
                     )
                 } else {
                     val income = dayList
-                        .filter { it.category.isIncome == 1 }
+                        .filter { it.category?.isIncome == 1 }
                         .sumOf { it.money }
                     val expense = dayList
-                        .filter { it.category.isIncome == 0 }
+                        .filter { it.category?.isIncome == 0 }
                         .sumOf { it.money }
 
                     dateItems.add(
@@ -97,5 +97,13 @@ class CalendarViewModel @Inject constructor(private val calendar: CustomCalendar
 
     fun isToday(dateItem: DateItem): Boolean {
         return dateItem.year == NOW_YEAR && dateItem.month == NOW_MONTH && dateItem.date == NOW_DAY
+    }
+
+    fun getDayOfWeek(year: Int, month: Int, date: Int): String {
+        return calendar.getDayOfWeek(year, month, date)
+    }
+
+    fun getMaxDate(year: Int, month: Int, date: Int): Int {
+        return calendar.getMaxDate(year, month, date)
     }
 }

--- a/app/src/main/java/com/woowa/accountbook/ui/calendar/CustomCalendar.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/calendar/CustomCalendar.kt
@@ -12,9 +12,9 @@ class CustomCalendar {
     val currentYearAndMonth = "${NOW_YEAR}년 ${NOW_MONTH}월"
     var yearMonthPair = Pair(NOW_YEAR, NOW_MONTH)
 
-    var currentMaxDate = 0
+    private var currentMaxDate = 0
     private var previousMonthOffset = 0
-    var nextMonthOffset = 0
+    private var nextMonthOffset = 0
 
     private val _dateList = mutableListOf<Pair<Int, Int>>()
     val dateList: List<Pair<Int, Int>> get() = _dateList
@@ -96,6 +96,31 @@ class CustomCalendar {
     private fun getCurrentMonthDate(calendar: Calendar) {
         repeat(calendar.getActualMaximum(Calendar.DATE)) {
             _dateList.add(0 to it + 1)
+        }
+    }
+
+    fun getMaxDate(year: Int, month: Int, date: Int): Int {
+        return Calendar.getInstance().apply {
+            set(Calendar.YEAR, year)
+            set(Calendar.MONTH, month - 1)
+            set(Calendar.DATE, date)
+        }.getActualMaximum(Calendar.DATE)
+    }
+
+    fun getDayOfWeek(year: Int, month: Int, date: Int): String {
+        val calendar = Calendar.getInstance().apply {
+            set(Calendar.YEAR, year)
+            set(Calendar.MONTH, month - 1)
+            set(Calendar.DATE, date)
+        }
+        return when (calendar.get(Calendar.DAY_OF_WEEK)) {
+            1 -> "일요일"
+            2 -> "월요일"
+            3 -> "화요일"
+            4 -> "수요일"
+            5 -> "목요일"
+            6 -> "금요일"
+            else -> "토요일"
         }
     }
 }

--- a/app/src/main/java/com/woowa/accountbook/ui/calendar/component/CalendarScreen.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/calendar/component/CalendarScreen.kt
@@ -214,7 +214,7 @@ fun CalendarItem(
                 color = LightPurple,
                 shape = RectangleShape
             )
-            .padding(4.dp)
+            .padding(2.dp)
             .clickable(
                 interactionSource = remember { MutableInteractionSource() },
                 onClick = { onClicked(dateItem) },

--- a/app/src/main/java/com/woowa/accountbook/ui/calendar/component/CalendarScreen.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/calendar/component/CalendarScreen.kt
@@ -93,12 +93,12 @@ fun CalendarScreen(
             Spacer(modifier = Modifier.height(16.dp))
             val totalViewModel = historyViewModel.totalHistory.collectAsState().value
             val monthTotalIncome =
-                totalViewModel.filter { it.category.isIncome == 1 }.sumOf { it.money }
+                totalViewModel.filter { it.category?.isIncome == 1 }.sumOf { it.money }
             val monthTotalExpense =
-                totalViewModel.filter { it.category.isIncome == 0 }.sumOf { it.money }
+                totalViewModel.filter { it.category?.isIncome == 0 }.sumOf { it.money }
             val totalIncome = rawToMoneyFormat(monthTotalIncome, 1)
             val totalExpense = rawToMoneyFormat(monthTotalExpense, 0)
-            val total = rawToMoneyFormat(monthTotalExpense + (-monthTotalIncome), 1)
+            val total = rawToMoneyFormat(monthTotalIncome - monthTotalExpense, 1)
             MonthIncomeAndExpense(totalIncome, totalExpense, total)
         }
     }

--- a/app/src/main/java/com/woowa/accountbook/ui/component/AppBar.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/component/AppBar.kt
@@ -21,11 +21,11 @@ import com.woowa.accountbook.ui.theme.Typography
 @Composable
 fun AccountBookAppBar(
     title: String,
-    navigationIcon: ImageVector?,
-    onNavigationClicked: () -> Unit,
-    actionIcon: ImageVector?,
+    navigationIcon: ImageVector? = null,
+    onNavigationClicked: () -> Unit = {},
+    actionIcon: ImageVector? = null,
     actionIconColor: Color = LocalContentColor.current.copy(alpha = LocalContentAlpha.current),
-    onActionClicked: () -> Unit,
+    onActionClicked: () -> Unit = {},
     backgroundColor: Color = OffWhite,
     contentColor: Color = Purple,
     dialog: @Composable (Boolean, (Boolean) -> Unit) -> Unit = { _, _ -> }

--- a/app/src/main/java/com/woowa/accountbook/ui/component/Button.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/component/Button.kt
@@ -75,8 +75,8 @@ fun LeftCornerCheckButton(
     disabledColor: Color,
     uncheckedColor: Color,
     checkmarkColor: Color,
-    labelText: String,
-    labelPriceText: String,
+    labelText: String = "",
+    labelPriceText: String = "",
 ) {
     AccountBookButton(
         modifier = Modifier
@@ -128,8 +128,8 @@ fun RightCornerCheckButton(
     disabledColor: Color,
     uncheckedColor: Color,
     checkmarkColor: Color,
-    labelText: String,
-    labelPriceText: String
+    labelText: String = "",
+    labelPriceText: String = ""
 ) {
     AccountBookButton(
         modifier = Modifier
@@ -172,6 +172,7 @@ fun RightCornerCheckButton(
 
 @Composable
 fun FilterCheckBoxButton(
+    checkbox: Boolean = true,
     totalIncome: Int,
     totalExpense: Int,
     inComeIsChecked: MutableState<Boolean>,
@@ -194,7 +195,7 @@ fun FilterCheckBoxButton(
     ) {
         LeftCornerCheckButton(
             enabled = enabled,
-            checkBox = true,
+            checkBox = checkbox,
             checked = inComeIsChecked.value,
             onClicked = {
                 onIncomeButtonClicked()
@@ -228,7 +229,7 @@ fun FilterCheckBoxButton(
 
         RightCornerCheckButton(
             enabled = enabled,
-            checkBox = true,
+            checkBox = checkbox,
             checked = expenseIsChecked.value,
             onClicked = {
                 onExpenseButtonClicked()
@@ -293,7 +294,7 @@ fun TextButton(
     }
 }
 
-private fun onClickFilterButton(
+fun onClickFilterButton(
     inComeIsChecked: MutableState<Boolean>,
     expenseIsChecked: MutableState<Boolean>,
     onBothClicked: () -> Unit,

--- a/app/src/main/java/com/woowa/accountbook/ui/component/Dialog.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/component/Dialog.kt
@@ -71,6 +71,47 @@ fun YearAndMonthPicker(
 }
 
 @Composable
+fun YearAndMonthAndDayPicker(
+    year: Int,
+    month: Int,
+    day: Int,
+    maxDate: Int,
+    onClicked: (Int, Int, Int) -> Unit
+) {
+    Column(
+        modifier = Modifier.padding(20.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        var selectedYear = year
+        var selectedMonth = month
+        var selectedDay = day
+        Row(
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            DateNumberPicker(1000..9999, year, onCompleted = { selectedYear = it })
+            Spacer(modifier = Modifier.width(15.dp))
+            DateNumberPicker(1..12, month, onCompleted = { selectedMonth = it })
+            Spacer(modifier = Modifier.width(15.dp))
+            DateNumberPicker(1..maxDate, day, onCompleted = { selectedDay = it })
+        }
+        TextButton(
+            text = "완료",
+            textColor = White,
+            modifier = Modifier
+                .fillMaxWidth(),
+            shape = RoundedCornerShape(14.dp),
+            onClicked = {
+                onClicked(selectedYear, selectedMonth, selectedDay)
+            },
+            isClick = true,
+            clickBackgroundColor = Yellow,
+            unClickBackgroundColor = Yellow
+        )
+    }
+}
+
+@Composable
 fun DateNumberPicker(
     intRange: IntRange,
     value: Int,
@@ -78,7 +119,7 @@ fun DateNumberPicker(
 ) {
     val pickerState = remember { mutableStateOf(value) }
     NumberPicker(
-        modifier = Modifier.width(200.dp),
+        modifier = Modifier.wrapContentWidth(),
         value = pickerState.value,
         onValueChange = {
             pickerState.value = it

--- a/app/src/main/java/com/woowa/accountbook/ui/component/DropdownMenu.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/component/DropdownMenu.kt
@@ -1,0 +1,128 @@
+package com.woowa.accountbook.ui.component
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
+import com.woowa.accountbook.data.entitiy.Category
+import com.woowa.accountbook.data.entitiy.Payment
+import com.woowa.accountbook.ui.iconpack.Down
+import com.woowa.accountbook.ui.iconpack.IconPack
+import com.woowa.accountbook.ui.iconpack.Plus
+import com.woowa.accountbook.ui.theme.Purple
+import com.woowa.accountbook.ui.theme.White
+
+@Composable
+fun InputDropDownMenu(
+    title: String,
+    paymentList: List<Payment> = emptyList(),
+    categoryList: List<Category> = emptyList(),
+    type: Int,
+    onSelected: (String?, Int?) -> Unit,
+    onAddItem: () -> Unit = {}
+) {
+    val expanded = remember { mutableStateOf(false) }
+    val rotateIcon = animateFloatAsState(
+        targetValue = if (expanded.value) 180f else 0f,
+        animationSpec = tween(durationMillis = 1000)
+    )
+
+    Row(modifier = Modifier
+        .fillMaxWidth()
+        .clickable { expanded.value = !expanded.value }) {
+        Text(
+            text = title,
+            color = Purple,
+            style = MaterialTheme.typography.body2,
+        )
+        Spacer(modifier = Modifier.weight(1f))
+        Icon(
+            imageVector = IconPack.Down,
+            contentDescription = "down_arrow",
+            modifier = Modifier.graphicsLayer { rotationZ = rotateIcon.value },
+            tint = Purple
+        )
+    }
+
+    MaterialTheme(shapes = MaterialTheme.shapes.copy(medium = RoundedCornerShape(16.dp))) {
+        DropdownMenu(
+            expanded = expanded.value,
+            onDismissRequest = { expanded.value = false },
+            offset = DpOffset(0.dp, 17.dp),
+            modifier = Modifier
+                .width(260.dp)
+                .height(150.dp)
+                .background(White)
+                .border(
+                    width = 1.dp,
+                    color = Purple,
+                    shape = RoundedCornerShape(16.dp)
+                ),
+        ) {
+            if (type == 0) {
+                paymentList.forEach {
+                    DropdownMenuItem(
+                        onClick = {
+                            onSelected(it.name, it.id)
+                            expanded.value = false
+                        }
+                    ) {
+                        Text(
+                            text = it.name,
+                            modifier = Modifier.weight(1f),
+                            color = Purple,
+                            style = MaterialTheme.typography.caption
+                        )
+                    }
+                }
+            } else {
+                categoryList.forEach {
+                    DropdownMenuItem(
+                        onClick = {
+                            onSelected(it.name, it.id)
+                            expanded.value = false
+                        }
+                    ) {
+                        Text(
+                            text = it.name ?: "",
+                            modifier = Modifier.weight(1f),
+                            color = Purple,
+                            style = MaterialTheme.typography.caption
+                        )
+                    }
+                }
+            }
+            DropdownMenuItem(
+                onClick = {}
+            ) {
+                Text(
+                    text = "추가하기",
+                    modifier = Modifier.weight(1f),
+                    color = Purple,
+                    style = MaterialTheme.typography.caption
+                )
+                IconButton(onClick = {}) {
+                    Icon(
+                        modifier = Modifier
+                            .width(14.dp)
+                            .height(14.dp),
+                                imageVector = IconPack . Plus,
+                        contentDescription = null,
+                        tint = Purple
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/woowa/accountbook/ui/component/List.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/component/List.kt
@@ -99,9 +99,13 @@ fun HistoryItem(
             BothSideText(
                 leftText = {
                     LabelText(
-                        text = history.category.name,
+                        text = history.category?.name ?: "",
                         textStyle = MaterialTheme.typography.caption,
-                        color = Color(android.graphics.Color.parseColor(history.category.color))
+                        color = if (history.category?.color == null) OffWhite else Color(
+                            android.graphics.Color.parseColor(
+                                history.category.color
+                            )
+                        )
                     )
                 },
                 rightText = {
@@ -122,9 +126,9 @@ fun HistoryItem(
                 },
                 rightText = {
                     Text(
-                        text = "${rawToMoneyFormat(history.money, history.category.isIncome)}원",
+                        text = "${rawToMoneyFormat(history.money, history.category?.isIncome)}원",
                         style = MaterialTheme.typography.subtitle2,
-                        color = if (history.category.isIncome == 1) Green3 else Red
+                        color = if (history.category?.isIncome == 1) Green3 else Red
                     )
                 }
             )

--- a/app/src/main/java/com/woowa/accountbook/ui/component/Text.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/component/Text.kt
@@ -1,22 +1,33 @@
 package com.woowa.accountbook.ui.component
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.woowa.accountbook.ui.theme.Green2
-import com.woowa.accountbook.ui.theme.Purple
-import com.woowa.accountbook.ui.theme.Red
-import com.woowa.accountbook.ui.theme.White
+import androidx.compose.ui.unit.sp
+import com.woowa.accountbook.ui.history.component.MoneyVisualTransformation
+import com.woowa.accountbook.ui.theme.*
 
 @Composable
 fun LabelText(
@@ -55,6 +66,134 @@ fun BothSideText(
         leftText()
         rightText()
     }
+}
+
+@Composable
+fun InputText(
+    label: String,
+    content: @Composable () -> Unit = {},
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 8.dp)
+    ) {
+        Text(
+            modifier = Modifier.weight(2f),
+            text = label,
+            style = MaterialTheme.typography.body2,
+            color = Purple
+        )
+        Row(modifier = Modifier.weight(9f)) { content() }
+    }
+    Divider(modifier = Modifier.padding(horizontal = 16.dp), color = Purple40)
+}
+
+@Composable
+fun InputDateText(
+    text: String,
+    dialog: @Composable (Boolean, (Boolean) -> Unit) -> Unit = { _, _ -> }
+) {
+    var isShowDialog by remember { mutableStateOf(false) }
+    Text(
+        text = text,
+        color = Purple,
+        style = MaterialTheme.typography.body2,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { isShowDialog = !isShowDialog }
+    )
+    dialog(isShowDialog) { isShowDialog = !it }
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+fun InputNumberText(
+    price: String,
+    onChanged: (String) -> Unit
+) {
+    val keyboardController = LocalSoftwareKeyboardController.current
+    BasicTextField(
+        value = price,
+        onValueChange = {
+            if (it == "") {
+                onChanged("")
+                return@BasicTextField
+            }
+            val amount = it.replace(("[^\\d.]").toRegex(), "")
+            onChanged(amount)
+        },
+        decorationBox = { innerTextField ->
+            if (price.isEmpty()) {
+                Text(
+                    "입력해주세요",
+                    style = MaterialTheme.typography.body2,
+                    color = Purple
+                )
+            }
+            innerTextField()
+        },
+        textStyle = TextStyle(
+            color = Purple,
+            fontSize = 14.sp,
+            fontWeight = FontWeight.Bold,
+            textDecoration = TextDecoration.None
+        ),
+        enabled = true,
+        keyboardOptions = KeyboardOptions(
+            capitalization = KeyboardCapitalization.None,
+            autoCorrect = true,
+            keyboardType = KeyboardType.Number,
+            imeAction = ImeAction.Done
+        ),
+        keyboardActions = KeyboardActions(
+            onDone = {
+                keyboardController?.hide()
+            }
+        ),
+        visualTransformation = MoneyVisualTransformation()
+    )
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+fun InputContentText(
+    content: String,
+    onChanged: (String) -> Unit
+) {
+    val keyboardController = LocalSoftwareKeyboardController.current
+    BasicTextField(
+        value = content,
+        onValueChange = { onChanged(it) },
+        decorationBox = { innerTextField ->
+            if (content.isEmpty()) {
+                Text(
+                    "입력해주세요",
+                    style = MaterialTheme.typography.body2,
+                    color = Purple
+                )
+            }
+            innerTextField()
+        },
+        textStyle = TextStyle(
+            color = Purple,
+            fontSize = 14.sp,
+            fontWeight = FontWeight.Bold,
+            textDecoration = TextDecoration.None
+        ),
+        enabled = true,
+        keyboardOptions = KeyboardOptions(
+            capitalization = KeyboardCapitalization.None,
+            autoCorrect = true,
+            keyboardType = KeyboardType.Text,
+            imeAction = ImeAction.Done
+        ),
+        keyboardActions = KeyboardActions(
+            onDone = {
+                keyboardController?.hide()
+            }
+        )
+    )
 }
 
 @Preview(showBackground = true)

--- a/app/src/main/java/com/woowa/accountbook/ui/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/history/HistoryViewModel.kt
@@ -1,20 +1,50 @@
 package com.woowa.accountbook.ui.history
 
 import androidx.lifecycle.ViewModel
+import com.woowa.accountbook.data.entitiy.Category
 import com.woowa.accountbook.data.entitiy.History
+import com.woowa.accountbook.data.entitiy.Payment
+import com.woowa.accountbook.domain.repository.category.CategoryRepository
 import com.woowa.accountbook.domain.repository.history.HistoryRepository
+import com.woowa.accountbook.domain.repository.payment.PaymentRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
 
 @HiltViewModel
-class HistoryViewModel @Inject constructor(private val historyRepository: HistoryRepository) :
+class HistoryViewModel @Inject constructor(
+    private val historyRepository: HistoryRepository,
+    private val paymentRepository: PaymentRepository,
+    private val categoryRepository: CategoryRepository
+) :
     ViewModel() {
 
     val totalHistory = MutableStateFlow<List<History>>(emptyList())
     private val _history = MutableStateFlow<List<History>>(emptyList())
     val history: StateFlow<List<History>> get() = _history
+
+    private val _payments = MutableStateFlow<List<Payment>>(emptyList())
+    val payments: StateFlow<List<Payment>> get() = _payments
+
+    private val _categories = MutableStateFlow<List<Category>>(emptyList())
+    val categories: StateFlow<List<Category>> get() = _categories
+
+    init {
+        savePayment("현대카드")
+        savePayment("카카오뱅크 체크카드")
+        saveCategory("교통", "#94D3CC", false)
+        saveCategory("문화/여가", "#D092E2", false)
+        saveCategory("미분류", "#817DCE", false)
+        saveCategory("생활", "#4A6CC3", false)
+        saveCategory("쇼핑/뷰티", "#4CB8B8", false)
+        saveCategory("식비", "#4CA1DE", false)
+        saveCategory("의료/건강", "#6ED5EB", false)
+        saveCategory("월급", "#9BD182", true)
+        saveCategory("용돈", "#EDCF65", true)
+        saveCategory("기타", "#E29C4D", true)
+        getPayments()
+    }
 
     fun initHistory(month: Int) {
         val result = historyRepository.getHistoriesByMonth(month).getOrThrow()
@@ -26,12 +56,12 @@ class HistoryViewModel @Inject constructor(private val historyRepository: Histor
     }
 
     fun getIncomeHistory() {
-        val incomeHistory = totalHistory.value.filter { it.category.isIncome == 1 }
+        val incomeHistory = totalHistory.value.filter { it.category?.isIncome == 1 }
         _history.value = incomeHistory
     }
 
     fun getExpenseHistory() {
-        val expenseHistory = totalHistory.value.filter { it.category.isIncome == 0 }
+        val expenseHistory = totalHistory.value.filter { it.category?.isIncome == 0 }
         _history.value = expenseHistory
     }
 
@@ -43,6 +73,38 @@ class HistoryViewModel @Inject constructor(private val historyRepository: Histor
         val result = historyRepository.getHistoriesMonthAndType(month, type).getOrThrow()
         _history.value = result
     }
+
+    fun saveHistory(
+        money: Int,
+        categoryId: Int?,
+        content: String,
+        year: Int,
+        month: Int,
+        day: Int,
+        paymentId: Int
+    ) {
+        historyRepository.saveHistory(money, categoryId, content, year, month, day, paymentId)
+    }
+
+    private fun saveCategory(name: String, color: String, isIncome: Boolean) {
+        categoryRepository.saveCategory(name, color, isIncome)
+    }
+
+    private fun savePayment(name: String) {
+        paymentRepository.savePayment(name)
+    }
+
+    private fun getPayments() {
+        val paymentList = paymentRepository.getPayments().getOrThrow()
+        _payments.value = paymentList
+    }
+
+    fun getCategories(type: String) {
+        val categoryList = categoryRepository.getCategoriesByType(type).getOrThrow()
+        _categories.value = categoryList
+    }
+
+    fun getDefaultCategory(): Int? = categories.value.find { it.name == "미분류" }?.id
 
     fun resetCheckedHistory() {
         _history.value = _history.value.map {

--- a/app/src/main/java/com/woowa/accountbook/ui/history/component/HistoryScreen.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/history/component/HistoryScreen.kt
@@ -39,6 +39,14 @@ fun HistoryScreen(
     val yearAndMonth = calendarViewModel.yearAndMonth.collectAsState().value
     val (year, month) = calendarViewModel.yearMonthPair.value
     historyViewModel.initHistory(month)
+    onClickFilterButton(
+        inComeIsChecked,
+        expenseIsChecked,
+        onIncomeClicked = { historyViewModel.getIncomeHistory() },
+        onExpenseClicked = { historyViewModel.getExpenseHistory() },
+        onBothClicked = { historyViewModel.getHistory() },
+        onEmptyClicked = { historyViewModel.getEmptyHistory() }
+    )
 
     Scaffold(
         backgroundColor = OffWhite,
@@ -103,9 +111,9 @@ fun HistoryScreen(
 
         val groupHistory = histories.groupBy { it.day }
         val monthTotalIncome =
-            totalViewModel.filter { it.category.isIncome == 1 }.sumOf { it.money }
+            totalViewModel.filter { it.category?.isIncome == 1 }.sumOf { it.money }
         val monthTotalExpense =
-            totalViewModel.filter { it.category.isIncome == 0 }.sumOf { it.money }
+            totalViewModel.filter { it.category?.isIncome == 0 }.sumOf { it.money }
 
         Column(modifier = Modifier.fillMaxSize()) {
             FilterCheckBoxButton(
@@ -163,9 +171,9 @@ private fun HistoryLazyColumn(
     LazyColumn {
         for (history in groupHistory) {
             val income =
-                history.value.filter { it.category.isIncome == 1 }.sumOf { it.money }
+                history.value.filter { it.category?.isIncome == 1 }.sumOf { it.money }
             val expense =
-                history.value.filter { it.category.isIncome == 0 }.sumOf { it.money }
+                history.value.filter { it.category?.isIncome == 0 }.sumOf { it.money }
             item {
                 HistoryItemTitle(
                     textColor = LightPurple,

--- a/app/src/main/java/com/woowa/accountbook/ui/history/component/MoneyVisualTransformation.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/history/component/MoneyVisualTransformation.kt
@@ -1,0 +1,24 @@
+package com.woowa.accountbook.ui.history.component
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.input.OffsetMapping
+import androidx.compose.ui.text.input.TransformedText
+import androidx.compose.ui.text.input.VisualTransformation
+import com.woowa.accountbook.common.stringToMoneyFormat
+
+class MoneyVisualTransformation() : VisualTransformation {
+    override fun filter(text: AnnotatedString): TransformedText {
+        val price = if (text.text != "") stringToMoneyFormat(text.text.toInt()) else ""
+
+        return TransformedText(
+            AnnotatedString(price),
+            object : OffsetMapping {
+                override fun originalToTransformed(offset: Int): Int {
+                    return price.length
+                }
+
+                override fun transformedToOriginal(offset: Int): Int = offset
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/woowa/accountbook/ui/history/component/RegistrationScreen.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/history/component/RegistrationScreen.kt
@@ -1,9 +1,267 @@
 package com.woowa.accountbook.ui.history.component
 
-import androidx.compose.material.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Scaffold
+import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.woowa.accountbook.common.NOW_DAY
+import com.woowa.accountbook.ui.calendar.CalendarViewModel
+import com.woowa.accountbook.ui.component.*
+import com.woowa.accountbook.ui.history.HistoryViewModel
+import com.woowa.accountbook.ui.iconpack.IconPack
+import com.woowa.accountbook.ui.iconpack.LeftArrow
+import com.woowa.accountbook.ui.theme.OffWhite
+import com.woowa.accountbook.ui.theme.Purple
+import com.woowa.accountbook.ui.theme.White
+import com.woowa.accountbook.ui.theme.Yellow
 
 @Composable
-fun RegistrationScreen() {
-    Text(text = "등록 화면")
+fun RegistrationScreen(
+    historyViewModel: HistoryViewModel = hiltViewModel(),
+    calendarViewModel: CalendarViewModel = hiltViewModel(),
+    navigationUp: () -> Unit = {}
+) {
+    val inComeIsChecked = rememberSaveable { mutableStateOf(true) }
+    val expenseIsChecked = rememberSaveable { mutableStateOf(false) }
+    val price = rememberSaveable { mutableStateOf("") }
+    val payment = rememberSaveable { mutableStateOf("선택하세요") }
+    val paymentId = rememberSaveable { mutableStateOf<Int?>(null) }
+    val content = rememberSaveable { mutableStateOf("") }
+    val category = rememberSaveable { mutableStateOf("선택하세요") }
+    val categoryId = rememberSaveable { mutableStateOf<Int?>(null) }
+    val (year, month) = calendarViewModel.yearMonthPair.value
+    val paymentList = historyViewModel.payments.collectAsState().value
+    val categoryList = historyViewModel.categories.collectAsState().value
+    if (inComeIsChecked.value) historyViewModel.getCategories("1") else historyViewModel.getCategories(
+        "0"
+    )
+    val selectedYear = rememberSaveable { mutableStateOf(year) }
+    val selectedMonth = rememberSaveable { mutableStateOf(month) }
+    val selectedDate = rememberSaveable { mutableStateOf(NOW_DAY) }
+
+    Scaffold(
+        backgroundColor = OffWhite,
+        topBar = {
+            AccountBookAppBar(
+                title = "내역 등록",
+                navigationIcon = IconPack.LeftArrow,
+                onNavigationClicked = { navigationUp() }
+            )
+        }
+    ) {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Spacer(modifier = Modifier.height(16.dp))
+            FilterButton(
+                inComeIsChecked,
+                expenseIsChecked,
+                price,
+                payment,
+                content,
+                category,
+                selectedYear,
+                year,
+                selectedMonth,
+                month,
+                selectedDate
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+
+            val maxDate = remember {
+                mutableStateOf(
+                    calendarViewModel.getMaxDate(
+                        selectedYear.value,
+                        selectedMonth.value,
+                        selectedDate.value
+                    )
+                )
+            }
+            InputText(
+                label = "일자",
+                content = {
+                    InputDateText(
+                        text = "${selectedYear.value}.${selectedMonth.value}.${selectedDate.value} ${
+                            calendarViewModel.getDayOfWeek(
+                                selectedYear.value,
+                                selectedMonth.value,
+                                selectedDate.value
+                            )
+                        }",
+                        dialog = { isShow, onDismissRequest ->
+                            AccountBookDialog(
+                                isShow = isShow,
+                                onDismissRequest = { onDismissRequest(it) },
+                                modifier = Modifier.fillMaxWidth(),
+                                content = {
+                                    YearAndMonthAndDayPicker(
+                                        selectedYear.value,
+                                        selectedMonth.value,
+                                        selectedDate.value,
+                                        maxDate.value,
+                                        onClicked = { year, month, day ->
+                                            onDismissRequest(it)
+                                            selectedYear.value = year
+                                            selectedMonth.value = month
+                                            selectedDate.value = day
+                                        }
+                                    )
+                                }
+                            )
+                        }
+                    )
+                },
+            )
+            InputText(label = "금액") {
+                InputNumberText(
+                    price.value, onChanged = { price.value = it },
+                )
+            }
+            InputText(label = if (inComeIsChecked.value) "입금수단" else "결제수단") {
+                InputDropDownMenu(
+                    title = payment.value,
+                    paymentList = paymentList,
+                    type = 0,
+                    onSelected = { name, id ->
+                        payment.value = name ?: ""
+                        paymentId.value = id
+                    }
+                )
+            }
+            InputText(label = "분류") {
+                InputDropDownMenu(
+                    title = category.value,
+                    categoryList = categoryList,
+                    type = 1,
+                    onSelected = { name, id ->
+                        category.value = name ?: ""
+                        categoryId.value = id
+                    }
+                )
+            }
+            InputText(label = "내용") {
+                InputContentText(content.value, onChanged = { content.value = it })
+            }
+            saveButton(
+                text = "등록하기",
+                onClicked = {
+                    historyViewModel.saveHistory(
+                        money = price.value.toInt(),
+                        categoryId = if (expenseIsChecked.value) {
+                            if (categoryId.value == null) historyViewModel.getDefaultCategory() else categoryId.value
+                        } else {
+                            categoryId.value
+                        },
+                        content = content.value,
+                        year = selectedYear.value,
+                        month = selectedMonth.value,
+                        day = selectedDate.value,
+                        paymentId = paymentId.value!!
+                    )
+                    navigationUp()
+                },
+                price = price.value,
+                paymentId.value,
+                payment.value
+            )
+        }
+    }
+}
+
+@Composable
+private fun saveButton(
+    text: String,
+    onClicked: () -> Unit,
+    price: String,
+    paymentId: Int?,
+    payment: String
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Bottom,
+        modifier = Modifier.fillMaxSize()
+    ) {
+        TextButton(
+            text = text,
+            textColor = White,
+            modifier = Modifier
+                .width(328.dp)
+                .height(50.dp),
+            shape = RoundedCornerShape(14.dp),
+            onClicked = { onClicked() },
+            isClick = true,
+            enabled = price != "" && payment != "선택하세요" && paymentId != null,
+            enabledBackgroundColor = Yellow.copy(alpha = 0.5f),
+            clickBackgroundColor = Yellow,
+            unClickBackgroundColor = Yellow
+        )
+        Spacer(modifier = Modifier.height(40.dp))
+    }
+}
+
+@Composable
+private fun FilterButton(
+    inComeIsChecked: MutableState<Boolean>,
+    expenseIsChecked: MutableState<Boolean>,
+    price: MutableState<String>,
+    payment: MutableState<String>,
+    content: MutableState<String>,
+    category: MutableState<String>,
+    selectedYear: MutableState<Int>,
+    year: Int,
+    selectedMonth: MutableState<Int>,
+    month: Int,
+    selectedDate: MutableState<Int>
+) {
+    Row() {
+        LeftCornerCheckButton(
+            checkBox = false,
+            checked = inComeIsChecked.value,
+            onClicked = {
+                inComeIsChecked.value = true
+                expenseIsChecked.value = false
+                price.value = ""
+                payment.value = "선택하세요"
+                content.value = ""
+                category.value = "선택하세요"
+                selectedYear.value = year
+                selectedMonth.value = month
+                selectedDate.value = NOW_DAY
+            },
+            onCheckedChange = { },
+            disabledColor = White,
+            checkedColor = White,
+            uncheckedColor = White,
+            checkmarkColor = Purple,
+            labelText = "수입",
+        )
+
+        RightCornerCheckButton(
+            checkBox = false,
+            checked = expenseIsChecked.value,
+            onClicked = {
+                inComeIsChecked.value = false
+                expenseIsChecked.value = true
+                price.value = ""
+                payment.value = "선택하세요"
+                content.value = ""
+                category.value = "선택하세요"
+                selectedYear.value = year
+                selectedMonth.value = month
+                selectedDate.value = NOW_DAY
+            },
+            onCheckedChange = { },
+            disabledColor = White,
+            checkedColor = White,
+            uncheckedColor = White,
+            checkmarkColor = Purple,
+            labelText = "지출",
+        )
+    }
 }

--- a/app/src/main/java/com/woowa/accountbook/ui/statistics/component/StatisticsScreen.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/statistics/component/StatisticsScreen.kt
@@ -44,7 +44,7 @@ fun StatisticsScreen(
     val (year, month) = calendarViewModel.yearMonthPair.value
     historyViewModel.getHistoryMonthAndType(month, false)
     val histories = historyViewModel.history.collectAsState().value
-    val groupBy = histories.groupBy { Pair(it.category.name, it.category.color) }
+    val groupBy = histories.groupBy { Pair(it.category?.name, it.category?.color) }
     val totalExpense = histories.sumOf { it.money }
 
     Scaffold(
@@ -103,8 +103,8 @@ fun StatisticsScreen(
 @Composable
 private fun ExpenseCategory(
     totalExpense: Int,
-    groupBy: Map<Pair<String, String>, List<History>>,
-    expenseCategoryList: List<Pair<Pair<String, String>, Int>>
+    groupBy: Map<Pair<String?, String?>, List<History>>,
+    expenseCategoryList: List<Pair<Pair<String?, String?>, Int>>
 ) {
     Column {
         BothSideText(
@@ -137,7 +137,7 @@ private fun ExpenseCategory(
 
 @Composable
 private fun GraphLegend(
-    expenseCategoryList: List<Pair<Pair<String, String>, Int>>,
+    expenseCategoryList: List<Pair<Pair<String?, String?>, Int>>,
     totalExpense: Int
 ) {
     LazyColumn(
@@ -154,7 +154,7 @@ private fun GraphLegend(
             ) {
                 Row {
                     LabelText(
-                        text = category.first.first,
+                        text = category.first.first!!,
                         textStyle = MaterialTheme.typography.caption,
                         color = Color(android.graphics.Color.parseColor(category.first.second))
                     )
@@ -187,7 +187,7 @@ private fun GraphLegend(
 
 @Composable
 private fun ExpenseGraph(
-    groupBy: Map<Pair<String, String>, List<History>>,
+    groupBy: Map<Pair<String?, String?>, List<History>>,
     totalExpense: Int,
 ) {
     AndroidView(

--- a/app/src/main/java/com/woowa/accountbook/ui/statistics/component/StatisticsScreen.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/statistics/component/StatisticsScreen.kt
@@ -44,7 +44,7 @@ fun StatisticsScreen(
     val (year, month) = calendarViewModel.yearMonthPair.value
     historyViewModel.getHistoryMonthAndType(month, false)
     val histories = historyViewModel.history.collectAsState().value
-    val groupBy = histories.groupBy { Pair(it.category?.name, it.category?.color) }
+    val groupBy = histories.groupBy { Pair(it.category?.name ?: "", it.category?.color ?: "#F7F6F3") }
     val totalExpense = histories.sumOf { it.money }
 
     Scaffold(
@@ -103,8 +103,8 @@ fun StatisticsScreen(
 @Composable
 private fun ExpenseCategory(
     totalExpense: Int,
-    groupBy: Map<Pair<String?, String?>, List<History>>,
-    expenseCategoryList: List<Pair<Pair<String?, String?>, Int>>
+    groupBy: Map<Pair<String, String>, List<History>>,
+    expenseCategoryList: List<Pair<Pair<String, String>, Int>>
 ) {
     Column {
         BothSideText(
@@ -137,7 +137,7 @@ private fun ExpenseCategory(
 
 @Composable
 private fun GraphLegend(
-    expenseCategoryList: List<Pair<Pair<String?, String?>, Int>>,
+    expenseCategoryList: List<Pair<Pair<String, String>, Int>>,
     totalExpense: Int
 ) {
     LazyColumn(
@@ -154,7 +154,7 @@ private fun GraphLegend(
             ) {
                 Row {
                     LabelText(
-                        text = category.first.first!!,
+                        text = category.first.first,
                         textStyle = MaterialTheme.typography.caption,
                         color = Color(android.graphics.Color.parseColor(category.first.second))
                     )
@@ -187,13 +187,13 @@ private fun GraphLegend(
 
 @Composable
 private fun ExpenseGraph(
-    groupBy: Map<Pair<String?, String?>, List<History>>,
+    groupBy: Map<Pair<String, String>, List<History>>,
     totalExpense: Int,
 ) {
     AndroidView(
         modifier = Modifier
             .fillMaxWidth()
-            .height(500.dp),
+            .height(300.dp),
         factory = { context ->
 
             val pieChart = PieChart(context)


### PR DESCRIPTION
### Issue

- closed #38 

### Description

### 데이터 설정

- 수입 내역을 등록 하실 카테고리를 지정하지 않아도 됨으로, null 처리로 수정

- 등록화면 뷰모델 공유
  - historyViewModel, calendarViewModel
- 파라미터 Default value 설정
- category 가 가지고 있는 속성에 따른 nullable 처리
  - income, expense
- 달력 기능 추가
  - 현재 몇 요일인지 판단하는 함수
  - 현재 달의 최대 일 구하는 함수
- sql
  Category 가 존재할 수도 있고 없을 수도 있으니 NOT NULL → NULL

### 데이터베이스 설정

- 내역 저장
  - 일자, 가격, 카테고리, 결제수단, 내용에 따른 저장하기

- id 값을 통해 조회
- Name 값을 통해 조회

- 중복처리
  - 카테고리, 결제수단 중복 저장되지 않도록 설정

- 널 처리된 정보도 가져올 수 있도록 수정

### 등록화면 구성

- 등록화면 일정 선택을 위해 dialog 생성
- 입금, 결제 수단, 분류 선택을 위해 드롭박스 생성
- 금액 돈 형식 포맷팅을 위한 VisualTransformation 설정
- 통계 화면 null 처리 개선
- InputText, InputDateText, InputContextText, InputDropboxMenu
  - 날짜 입력, 글자 입력, 드롭박스 설정 컴포넌트 생성