### PR TITLE
설정 화면 구성하기

### DIFF
--- a/app/src/main/java/com/woowa/accountbook/data/entitiy/Category.kt
+++ b/app/src/main/java/com/woowa/accountbook/data/entitiy/Category.kt
@@ -4,5 +4,6 @@ data class Category(
     val id: Int?,
     val isIncome: Int?,
     val name: String?,
-    val color: String?
+    val color: String?,
+    var isChecked: Boolean = false
 )

--- a/app/src/main/java/com/woowa/accountbook/data/entitiy/Payment.kt
+++ b/app/src/main/java/com/woowa/accountbook/data/entitiy/Payment.kt
@@ -2,5 +2,6 @@ package com.woowa.accountbook.data.entitiy
 
 data class Payment(
     val id: Int,
-    val name: String
+    val name: String,
+    var isChecked: Boolean = false
 )

--- a/app/src/main/java/com/woowa/accountbook/data/local/category/CategoryDataSource.kt
+++ b/app/src/main/java/com/woowa/accountbook/data/local/category/CategoryDataSource.kt
@@ -5,7 +5,7 @@ import com.woowa.accountbook.data.entitiy.Category
 interface CategoryDataSource {
 
     fun findById(id: Int): Category?
-    fun findByName(name: String): Category?
+    fun findByNameAndIsIncome(name: String, isIncome: String): Category?
     fun findByType(type: String): List<Category>
     fun deleteById(list: List<Int>)
     fun save(name: String, color: String, isIncome: Boolean)

--- a/app/src/main/java/com/woowa/accountbook/data/local/category/CategoryLocalDataSource.kt
+++ b/app/src/main/java/com/woowa/accountbook/data/local/category/CategoryLocalDataSource.kt
@@ -27,11 +27,11 @@ class CategoryLocalDataSource @Inject constructor(
         }
     }
 
-    override fun findByName(name: String): Category? {
+    override fun findByNameAndIsIncome(name: String, isIncome: String): Category? {
         databaseHelper.readableDatabase.use { database ->
             val sql =
-                "SELECT * FROM ${DatabaseHelper.TABLE_CATEGORY} WHERE ${DatabaseHelper.CATEGORY_COL_NAME} = ?"
-            val cursor = database.rawQuery(sql, arrayOf(name))
+                "SELECT * FROM ${DatabaseHelper.TABLE_CATEGORY} WHERE ${DatabaseHelper.CATEGORY_COL_NAME} = ? AND ${DatabaseHelper.CATEGORY_COL_IS_INCOME} = ?"
+            val cursor = database.rawQuery(sql, arrayOf(name, isIncome))
             return cursor.use {
                 if (it.moveToNext()) {
                     Category(

--- a/app/src/main/java/com/woowa/accountbook/data/repository/CategoryRepositoryImpl.kt
+++ b/app/src/main/java/com/woowa/accountbook/data/repository/CategoryRepositoryImpl.kt
@@ -19,7 +19,8 @@ class CategoryRepositoryImpl @Inject constructor(
 
     override fun saveCategory(name: String, color: String, isIncome: Boolean) {
         runCatching {
-            val category = categoryDataSource.findByName(name)
+            val category =
+                categoryDataSource.findByNameAndIsIncome(name, if (isIncome) "1" else "0")
             if (category == null)
                 categoryDataSource.save(name, color, isIncome)
         }

--- a/app/src/main/java/com/woowa/accountbook/ui/AccountBookAppState.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/AccountBookAppState.kt
@@ -27,6 +27,7 @@ object Destinations {
     const val REGISTRATION = "home/history/registration"
     const val HOME = "home"
     const val STATISTICS_DETAIL = "home/statistics/detail"
+    const val SETTING_REGISTRATION = "home/setting/registration"
 }
 
 @Composable
@@ -72,6 +73,12 @@ class AccountBookState(
     fun navigateToRegistration(route: String, id: Int = -1) {
         if (route != currentRoute) {
             navController.navigate("${route}/${id}")
+        }
+    }
+
+    fun navigateToSettingRegistration(route: String, id: Int?, type: String) {
+        if (route != currentRoute) {
+            navController.navigate("${route}/${id}/${type}")
         }
     }
 }

--- a/app/src/main/java/com/woowa/accountbook/ui/calendar/component/CalendarScreen.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/calendar/component/CalendarScreen.kt
@@ -80,6 +80,12 @@ fun CalendarScreen(
             )
         }
     ) {
+        Divider(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(1.dp)
+                .background(LightPurple)
+        )
         Column(
             modifier = Modifier.verticalScroll(rememberScrollState())
         ) {

--- a/app/src/main/java/com/woowa/accountbook/ui/component/AppBar.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/component/AppBar.kt
@@ -34,6 +34,7 @@ fun AccountBookAppBar(
     TopAppBar(
         backgroundColor = backgroundColor,
         contentColor = contentColor,
+        elevation = 0.dp,
         title = {
             Text(
                 modifier = when (actionIcon) {

--- a/app/src/main/java/com/woowa/accountbook/ui/component/DropdownMenu.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/component/DropdownMenu.kt
@@ -30,7 +30,7 @@ fun InputDropDownMenu(
     categoryList: List<Category> = emptyList(),
     type: Int,
     onSelected: (String?, Int?) -> Unit,
-    onAddItem: () -> Unit = {}
+    onAddItem: (Int?) -> Unit = {}
 ) {
     val expanded = remember { mutableStateOf(false) }
     val rotateIcon = animateFloatAsState(
@@ -104,7 +104,7 @@ fun InputDropDownMenu(
                 }
             }
             DropdownMenuItem(
-                onClick = {}
+                onClick = { onAddItem(-1) }
             ) {
                 Text(
                     text = "추가하기",
@@ -112,7 +112,7 @@ fun InputDropDownMenu(
                     color = Purple,
                     style = MaterialTheme.typography.caption
                 )
-                IconButton(onClick = {}) {
+                IconButton(onClick = { onAddItem(-1) }) {
                     Icon(
                         modifier = Modifier
                             .width(14.dp)

--- a/app/src/main/java/com/woowa/accountbook/ui/component/List.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/component/List.kt
@@ -1,6 +1,5 @@
 package com.woowa.accountbook.ui.component
 
-import android.util.Log
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.*

--- a/app/src/main/java/com/woowa/accountbook/ui/component/List.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/component/List.kt
@@ -1,5 +1,6 @@
 package com.woowa.accountbook.ui.component
 
+import android.util.Log
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.*
@@ -21,8 +22,8 @@ import com.woowa.accountbook.ui.theme.*
 fun HistoryItemTitle(
     textColor: Color,
     title: String,
-    income: String,
-    expense: String
+    income: String? = null,
+    expense: String? = null
 ) {
     Spacer(modifier = Modifier.height(24.dp))
     Row(
@@ -38,34 +39,84 @@ fun HistoryItemTitle(
             color = textColor
         )
 
-        Row {
-            Text(
-                text = "수입",
-                style = MaterialTheme.typography.caption,
-                color = textColor
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-            Text(
-                text = income,
-                style = MaterialTheme.typography.caption,
-                color = textColor
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-            Text(
-                text = "지출",
-                style = MaterialTheme.typography.caption,
-                color = textColor
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-            Text(
-                text = expense,
-                style = MaterialTheme.typography.caption,
-                color = textColor
-            )
+        if (income != null && expense != null) {
+            Row {
+                Text(
+                    text = "수입",
+                    style = MaterialTheme.typography.caption,
+                    color = textColor
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = income,
+                    style = MaterialTheme.typography.caption,
+                    color = textColor
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = "지출",
+                    style = MaterialTheme.typography.caption,
+                    color = textColor
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = expense,
+                    style = MaterialTheme.typography.caption,
+                    color = textColor
+                )
+            }
         }
     }
     Spacer(modifier = Modifier.height(8.dp))
 }
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun SettingItem(
+    category: Category? = null,
+    payment: Payment? = null,
+    isEdit: Boolean,
+    onClicked: (Int?) -> Unit = {},
+    onLongClicked: (Boolean, Int?) -> Unit = { _, _ -> },
+    onCheckedItem: (Boolean, Int?) -> Unit = { _, _ -> },
+    content: @Composable () -> Unit = {}
+) {
+    Row(
+        modifier = Modifier
+            .combinedClickable(
+                onClick = {
+                    if (!isEdit) {
+                        if (category != null) onClicked(category.id)
+                        if (payment != null) onClicked(payment.id)
+                    }
+                },
+                onLongClick = {
+                    if (category != null) onLongClicked(isEdit, category.id)
+                    if (payment != null) onLongClicked(isEdit, payment.id)
+                }
+            ),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        if (isEdit) {
+            Spacer(modifier = Modifier.width(16.dp))
+            AccountBookCheckBox(
+                checked = category?.isChecked ?: (payment?.isChecked ?: false),
+                onCheckedChange = {
+                    if (category != null) onCheckedItem(it, category.id)
+                    if (payment != null) onCheckedItem(it, payment.id)
+                },
+                checkedColor = Red,
+                uncheckedColor = Purple,
+                checkmarkColor = White
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+        }
+        Column {
+            content()
+        }
+    }
+}
+
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable

--- a/app/src/main/java/com/woowa/accountbook/ui/component/Text.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/component/Text.kt
@@ -170,7 +170,7 @@ fun InputContentText(
                 Text(
                     "입력해주세요",
                     style = MaterialTheme.typography.body2,
-                    color = Purple
+                    color = LightPurple
                 )
             }
             innerTextField()

--- a/app/src/main/java/com/woowa/accountbook/ui/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/history/HistoryViewModel.kt
@@ -104,7 +104,7 @@ class HistoryViewModel @Inject constructor(
         historyRepository.updateHistory(id, money, categoryId, content, year, month, day, paymentId)
     }
 
-    private fun getPayments() {
+    fun getPayments() {
         val paymentList = paymentRepository.getPayments().getOrThrow()
         _payments.value = paymentList
     }

--- a/app/src/main/java/com/woowa/accountbook/ui/history/component/HistoryScreen.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/history/component/HistoryScreen.kt
@@ -107,6 +107,12 @@ fun HistoryScreen(
             }
         }
     ) {
+        Divider(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(1.dp)
+                .background(LightPurple)
+        )
         val totalHistory = historyViewModel.totalHistory.collectAsState().value
         val histories = historyViewModel.history.collectAsState().value
 

--- a/app/src/main/java/com/woowa/accountbook/ui/history/component/RegistrationScreen.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/history/component/RegistrationScreen.kt
@@ -1,7 +1,9 @@
 package com.woowa.accountbook.ui.history.component
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Divider
 import androidx.compose.material.Scaffold
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -16,10 +18,7 @@ import com.woowa.accountbook.ui.component.*
 import com.woowa.accountbook.ui.history.HistoryViewModel
 import com.woowa.accountbook.ui.iconpack.IconPack
 import com.woowa.accountbook.ui.iconpack.LeftArrow
-import com.woowa.accountbook.ui.theme.OffWhite
-import com.woowa.accountbook.ui.theme.Purple
-import com.woowa.accountbook.ui.theme.White
-import com.woowa.accountbook.ui.theme.Yellow
+import com.woowa.accountbook.ui.theme.*
 
 @Composable
 fun RegistrationScreen(
@@ -67,6 +66,12 @@ fun RegistrationScreen(
             )
         }
     ) {
+        Divider(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(1.dp)
+                .background(LightPurple)
+        )
         Column(
             modifier = Modifier.fillMaxSize(),
             horizontalAlignment = Alignment.CenterHorizontally

--- a/app/src/main/java/com/woowa/accountbook/ui/history/component/RegistrationScreen.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/history/component/RegistrationScreen.kt
@@ -25,10 +25,13 @@ fun RegistrationScreen(
     id: Int,
     historyViewModel: HistoryViewModel = hiltViewModel(),
     calendarViewModel: CalendarViewModel = hiltViewModel(),
-    navigationUp: () -> Unit = {}
+    navigationUp: () -> Unit = {},
+    onSectionItemClicked: (Int?, String) -> Unit,
 ) {
     val updateMode = -1
     historyViewModel.getHistory(id)
+    historyViewModel.getPayments()
+
     val history = historyViewModel.currentHistory.collectAsState().value
     var isIncome = history?.category?.isIncome == 1
     var isExpense = history?.category?.isIncome == 0
@@ -152,7 +155,8 @@ fun RegistrationScreen(
                     onSelected = { name, id ->
                         payment.value = name ?: ""
                         paymentId.value = id
-                    }
+                    },
+                    onAddItem = { onSectionItemClicked(it, "payment") }
                 )
             }
             InputText(label = "분류") {
@@ -163,6 +167,12 @@ fun RegistrationScreen(
                     onSelected = { name, id ->
                         category.value = name ?: ""
                         categoryId.value = id
+                    },
+                    onAddItem = {
+                        onSectionItemClicked(
+                            it,
+                            if (inComeIsChecked.value) "income" else "expense"
+                        )
                     }
                 )
             }

--- a/app/src/main/java/com/woowa/accountbook/ui/settings/SettingViewModel.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/settings/SettingViewModel.kt
@@ -1,0 +1,102 @@
+package com.woowa.accountbook.ui.settings
+
+import androidx.lifecycle.ViewModel
+import com.woowa.accountbook.data.entitiy.Category
+import com.woowa.accountbook.data.entitiy.Payment
+import com.woowa.accountbook.domain.repository.category.CategoryRepository
+import com.woowa.accountbook.domain.repository.payment.PaymentRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class SettingViewModel @Inject constructor(
+    private val paymentRepository: PaymentRepository,
+    private val categoryRepository: CategoryRepository
+) : ViewModel() {
+
+    private val _payments = MutableStateFlow<List<Payment>>(emptyList())
+    val payments: StateFlow<List<Payment>> get() = _payments
+
+    private val _incomeCategories = MutableStateFlow<List<Category>>(emptyList())
+    val incomeCategories: StateFlow<List<Category>> get() = _incomeCategories
+
+    private val _expenseCategories = MutableStateFlow<List<Category>>(emptyList())
+    val expenseCategories: StateFlow<List<Category>> get() = _expenseCategories
+
+    init {
+        getPayments()
+        getExpenseCategories()
+        getIncomeCategories()
+    }
+
+    fun getPayments() {
+        val paymentList = paymentRepository.getPayments().getOrThrow()
+        _payments.value = paymentList
+    }
+
+    fun getIncomeCategories() {
+        val categoryList = categoryRepository.getCategoriesByType("1").getOrThrow()
+        _incomeCategories.value = categoryList
+    }
+
+    fun getExpenseCategories() {
+        val categoryList = categoryRepository.getCategoriesByType("0").getOrThrow()
+        _expenseCategories.value = categoryList
+    }
+
+    fun setCheckedItem(isChecked: Boolean, id: Int?, type: String) {
+        when(type) {
+            "payment" -> {
+                _payments.value = _payments.value.map {
+                    if(it.id == id) it.copy(isChecked = isChecked) else it
+                }
+            }
+            "expense" -> {
+                _expenseCategories.value = _expenseCategories.value.map {
+                    if(it.id == id) it.copy(isChecked = isChecked) else it
+                }
+            }
+            "income" -> {
+                _incomeCategories.value = _incomeCategories.value.map {
+                    if(it.id == id) it.copy(isChecked = isChecked) else it
+                }
+            }
+        }
+    }
+
+    fun resetCheckedItem(type: String) {
+        when(type) {
+            "payment" -> {
+                _payments.value = _payments.value.map {
+                    it.copy(isChecked = false)
+                }
+            }
+            "expense" -> {
+                _expenseCategories.value = _expenseCategories.value.map {
+                    it.copy(isChecked = false)
+                }
+            }
+            "income" -> {
+                _incomeCategories.value = _incomeCategories.value.map {
+                    it.copy(isChecked = false)
+                }
+            }
+        }
+    }
+
+    fun removeItem(type: String) {
+        when(type) {
+            "payment" -> {
+                resetCheckedItem(type)
+            }
+            "expense" -> {
+                resetCheckedItem(type)
+            }
+            "income" -> {
+                resetCheckedItem(type)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/woowa/accountbook/ui/settings/SettingViewModel.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/settings/SettingViewModel.kt
@@ -1,5 +1,7 @@
 package com.woowa.accountbook.ui.settings
 
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.lifecycle.ViewModel
 import com.woowa.accountbook.data.entitiy.Category
 import com.woowa.accountbook.data.entitiy.Payment
@@ -25,12 +27,6 @@ class SettingViewModel @Inject constructor(
     private val _expenseCategories = MutableStateFlow<List<Category>>(emptyList())
     val expenseCategories: StateFlow<List<Category>> get() = _expenseCategories
 
-    init {
-        getPayments()
-        getExpenseCategories()
-        getIncomeCategories()
-    }
-
     fun getPayments() {
         val paymentList = paymentRepository.getPayments().getOrThrow()
         _payments.value = paymentList
@@ -46,28 +42,37 @@ class SettingViewModel @Inject constructor(
         _expenseCategories.value = categoryList
     }
 
+    fun savePayment(name: String) {
+        paymentRepository.savePayment(name)
+    }
+
+    fun saveCategory(name: String, isIncome: Boolean, color: Color) {
+        val stringColor = String.format("#%06X", (0xFFFFFF and color.toArgb()))
+        categoryRepository.saveCategory(name, stringColor, isIncome)
+    }
+
     fun setCheckedItem(isChecked: Boolean, id: Int?, type: String) {
-        when(type) {
+        when (type) {
             "payment" -> {
                 _payments.value = _payments.value.map {
-                    if(it.id == id) it.copy(isChecked = isChecked) else it
+                    if (it.id == id) it.copy(isChecked = isChecked) else it
                 }
             }
             "expense" -> {
                 _expenseCategories.value = _expenseCategories.value.map {
-                    if(it.id == id) it.copy(isChecked = isChecked) else it
+                    if (it.id == id) it.copy(isChecked = isChecked) else it
                 }
             }
             "income" -> {
                 _incomeCategories.value = _incomeCategories.value.map {
-                    if(it.id == id) it.copy(isChecked = isChecked) else it
+                    if (it.id == id) it.copy(isChecked = isChecked) else it
                 }
             }
         }
     }
 
     fun resetCheckedItem(type: String) {
-        when(type) {
+        when (type) {
             "payment" -> {
                 _payments.value = _payments.value.map {
                     it.copy(isChecked = false)
@@ -87,7 +92,7 @@ class SettingViewModel @Inject constructor(
     }
 
     fun removeItem(type: String) {
-        when(type) {
+        when (type) {
             "payment" -> {
                 resetCheckedItem(type)
             }

--- a/app/src/main/java/com/woowa/accountbook/ui/settings/component/RegistrationSectionScreen.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/settings/component/RegistrationSectionScreen.kt
@@ -1,0 +1,182 @@
+package com.woowa.accountbook.ui.settings.component
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.GridCells
+import androidx.compose.foundation.lazy.LazyVerticalGrid
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Divider
+import androidx.compose.material.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.woowa.accountbook.ui.component.*
+import com.woowa.accountbook.ui.iconpack.IconPack
+import com.woowa.accountbook.ui.iconpack.LeftArrow
+import com.woowa.accountbook.ui.settings.SettingViewModel
+import com.woowa.accountbook.ui.theme.*
+
+@Composable
+fun RegistrationSectionScreen(
+    settingViewModel: SettingViewModel = hiltViewModel(),
+    id: Int,
+    type: String?,
+    navigationUp: () -> Unit
+) {
+    val updateMode = -1
+    val title = if (id == updateMode) {
+        when (type) {
+            "expense" -> "지출 카테고리 추가"
+            "income" -> "수입 카테고리 추가"
+            else -> "결제 수단 추가하기"
+        }
+    } else {
+        when (type) {
+            "expense" -> "지출 카테고리 수정"
+            "income" -> "수입 카테고리 수정"
+            else -> "결제 수단 수정하기"
+        }
+    }
+
+    val name = rememberSaveable { mutableStateOf("") }
+    Scaffold(
+        backgroundColor = OffWhite,
+        topBar = {
+            AccountBookAppBar(
+                title = title,
+                navigationIcon = IconPack.LeftArrow,
+                onNavigationClicked = { navigationUp() }
+            )
+        }
+    ) {
+        Divider(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(1.dp)
+                .background(LightPurple)
+        )
+        Column {
+            InputText(label = "이름") {
+                InputContentText(name.value, onChanged = { name.value = it })
+            }
+
+            val colorList = if (type == "expense") expenseColorList else incomeColorList
+            val selectedItem = remember { mutableStateOf(colorList.first()) }
+            if (type == "expense" || type == "income") {
+                InputColor(colorList, selectedItem)
+            }
+            SaveButton(id, updateMode, type, settingViewModel, name, selectedItem, navigationUp)
+        }
+    }
+}
+
+@Composable
+private fun InputColor(
+    colorList: List<Color>,
+    selectedItem: MutableState<Color>
+) {
+    HistoryItemTitle(textColor = LightPurple, title = "색상")
+    Divider(modifier = Modifier.padding(horizontal = 16.dp), color = Purple40)
+    ColorPalette(
+        colorList = colorList,
+        selectedItem = selectedItem.value,
+        onClicked = { selectedItem.value = it }
+    )
+    Spacer(
+        modifier = Modifier
+            .height(1.dp)
+            .fillMaxWidth()
+            .background(LightPurple)
+    )
+}
+
+@Composable
+private fun SaveButton(
+    id: Int,
+    updateMode: Int,
+    type: String?,
+    settingViewModel: SettingViewModel,
+    name: MutableState<String>,
+    selectedItem: MutableState<Color>,
+    navigationUp: () -> Unit
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Bottom,
+        modifier = Modifier.fillMaxSize()
+    ) {
+        TextButton(
+            text = if (id == updateMode) "등록하기" else "수정하기",
+            textColor = White,
+            modifier = Modifier
+                .width(328.dp)
+                .height(50.dp),
+            shape = RoundedCornerShape(14.dp),
+            onClicked = {
+                if (id == updateMode && (type == "expense" || type == "income")) {
+                    settingViewModel.saveCategory(
+                        name.value,
+                        type != "expense",
+                        selectedItem.value
+                    )
+                }
+                if (id == updateMode && type == "payment") {
+                    settingViewModel.savePayment(name.value)
+                }
+                navigationUp()
+            },
+            isClick = true,
+            enabled = name.value != "" && !name.value.contains(" "),
+            enabledBackgroundColor = Yellow.copy(alpha = 0.5f),
+            clickBackgroundColor = Yellow,
+            unClickBackgroundColor = Yellow
+        )
+        Spacer(modifier = Modifier.height(40.dp))
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun ColorPalette(colorList: List<Color>, selectedItem: Color, onClicked: (Color) -> Unit) {
+
+    LazyVerticalGrid(
+        modifier = Modifier.selectableGroup(),
+        cells = GridCells.Fixed(count = 10),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+        verticalArrangement = Arrangement.spacedBy(20.dp),
+        contentPadding = PaddingValues(16.dp)
+    ) {
+        items(colorList) { color ->
+            Box(
+                modifier = Modifier
+                    .background(color)
+                    .width(24.dp)
+                    .height(24.dp)
+                    .border(
+                        width = if (selectedItem == color) 0.dp else 4.dp,
+                        color = OffWhite
+                    )
+                    .selectable(
+                        selected = selectedItem == color,
+                        enabled = true,
+                        role = Role.RadioButton
+                    ) {
+                        onClicked(color)
+                    }
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/woowa/accountbook/ui/settings/component/SettingScreen.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/settings/component/SettingScreen.kt
@@ -1,23 +1,88 @@
 package com.woowa.accountbook.ui.settings.component
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.material.Divider
-import androidx.compose.material.Scaffold
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.woowa.accountbook.ui.component.AccountBookAppBar
-import com.woowa.accountbook.ui.theme.LightPurple
-import com.woowa.accountbook.ui.theme.OffWhite
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.woowa.accountbook.data.entitiy.Category
+import com.woowa.accountbook.data.entitiy.Payment
+import com.woowa.accountbook.ui.component.*
+import com.woowa.accountbook.ui.iconpack.IconPack
+import com.woowa.accountbook.ui.iconpack.LeftArrow
+import com.woowa.accountbook.ui.iconpack.Plus
+import com.woowa.accountbook.ui.iconpack.Trash
+import com.woowa.accountbook.ui.settings.SettingViewModel
+import com.woowa.accountbook.ui.theme.*
 
 @Composable
-fun SettingScreen() {
+fun SettingScreen(settingViewModel: SettingViewModel = hiltViewModel()) {
+
+    val paymentEditMode = remember { mutableStateOf(false) }
+    val expenseEditMode = remember { mutableStateOf(false) }
+    val incomeEditMode = remember { mutableStateOf(false) }
+    val payments = settingViewModel.payments.collectAsState().value
+    val expenseCategories = settingViewModel.expenseCategories.collectAsState().value
+    val incomeCategories = settingViewModel.incomeCategories.collectAsState().value
+
     Scaffold(
         backgroundColor = OffWhite,
         topBar = {
-            AccountBookAppBar(title = "설정")
+            if (!paymentEditMode.value && !expenseEditMode.value && !incomeEditMode.value) {
+                AccountBookAppBar(title = "설정")
+            } else {
+
+                AccountBookAppBar(
+                    title = if (paymentEditMode.value)
+                        "${payments.count { it.isChecked }}개 선택"
+                    else if (expenseEditMode.value)
+                        "${expenseCategories.count { it.isChecked }}개 선택"
+                    else
+                        "${incomeCategories.count { it.isChecked }}개 선택",
+                    navigationIcon = IconPack.LeftArrow,
+                    onNavigationClicked = {
+                        if(paymentEditMode.value) {
+                            paymentEditMode.value = !paymentEditMode.value
+                            settingViewModel.resetCheckedItem("payment")
+                        }
+                        else if(expenseEditMode.value) {
+                            expenseEditMode.value = !expenseEditMode.value
+                            settingViewModel.resetCheckedItem("expense")
+                        }
+                        else {
+                            incomeEditMode.value = !incomeEditMode.value
+                            settingViewModel.resetCheckedItem("income")
+                        }
+                    },
+                    actionIcon = IconPack.Trash,
+                    actionIconColor = Red,
+                    onActionClicked = {
+                        if(paymentEditMode.value) {
+                            paymentEditMode.value = !paymentEditMode.value
+                            settingViewModel.removeItem("payment")
+                        }
+                        else if(expenseEditMode.value) {
+                            expenseEditMode.value = !expenseEditMode.value
+                            settingViewModel.removeItem("expense")
+                        }
+                        else {
+                            incomeEditMode.value = !incomeEditMode.value
+                            settingViewModel.removeItem("income")
+                        }
+                    }
+                )
+            }
         }
     ) {
         Divider(
@@ -26,5 +91,171 @@ fun SettingScreen() {
                 .height(1.dp)
                 .background(LightPurple)
         )
+
+        LazyColumn {
+            section(
+                title = "결제수단",
+                payments = payments,
+                editMode = paymentEditMode.value,
+                onClicked = {},
+                onLongClicked = { mode, id ->
+                    paymentEditMode.value = !mode
+                    expenseEditMode.value = false
+                    incomeEditMode.value = false
+                    settingViewModel.resetCheckedItem("expense")
+                    settingViewModel.resetCheckedItem("income")
+                    settingViewModel.setCheckedItem(true, id, "payment")
+                    if (!paymentEditMode.value) settingViewModel.resetCheckedItem("payment")
+                },
+                onCheckedItem = { isChecked, id ->
+                    settingViewModel.setCheckedItem(isChecked, id, "payment")
+                }
+            )
+            section(
+                title = "지출 카테고리",
+                category = expenseCategories,
+                editMode = expenseEditMode.value,
+                onClicked = {},
+                onLongClicked = { mode, id ->
+                    paymentEditMode.value = false
+                    expenseEditMode.value = !mode
+                    incomeEditMode.value = false
+                    settingViewModel.resetCheckedItem("payment")
+                    settingViewModel.resetCheckedItem("income")
+                    settingViewModel.setCheckedItem(true, id, "expense")
+                    if (!expenseEditMode.value) settingViewModel.resetCheckedItem("expense")
+                },
+                onCheckedItem = { isChecked, id ->
+                    settingViewModel.setCheckedItem(isChecked, id, "expense")
+                }
+            )
+            section(
+                title = "수입 카테고리",
+                category = incomeCategories,
+                editMode = incomeEditMode.value,
+                onClicked = {},
+                onLongClicked = { mode, id ->
+                    paymentEditMode.value = false
+                    expenseEditMode.value = false
+                    incomeEditMode.value = !mode
+                    settingViewModel.resetCheckedItem("payment")
+                    settingViewModel.resetCheckedItem("expense")
+                    settingViewModel.setCheckedItem(true, id, "income")
+                    if (!incomeEditMode.value) settingViewModel.resetCheckedItem("income")
+                },
+                onCheckedItem = { isChecked, id ->
+                    settingViewModel.setCheckedItem(isChecked, id, "income")
+                }
+            )
+        }
     }
+}
+
+private fun LazyListScope.section(
+    title: String,
+    payments: List<Payment> = emptyList(),
+    category: List<Category> = emptyList(),
+    editMode: Boolean = false,
+    onClicked: () -> Unit = {},
+    onLongClicked: (Boolean, Int?) -> Unit = { _, _ -> },
+    onCheckedItem: (Boolean, Int?) -> Unit = { _, _ -> },
+) {
+    item {
+        HistoryItemTitle(textColor = LightPurple, title = title)
+    }
+    if (payments.isNotEmpty()) {
+        itemsIndexed(payments) { idx, item ->
+            Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+                Divider(color = Purple40)
+                SettingItem(
+                    payment = item,
+                    isEdit = editMode,
+                    onClicked = { },
+                    onLongClicked = { editMode, id -> onLongClicked(editMode, id) },
+                    onCheckedItem = { isChecked, id -> onCheckedItem(isChecked, id) }
+                ) {
+                    Text(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 12.dp),
+                        text = item.name,
+                        style = MaterialTheme.typography.subtitle2,
+                        color = Purple
+                    )
+                }
+            }
+        }
+    }
+    if (category.isNotEmpty()) {
+        itemsIndexed(category) { idx, item ->
+            Column {
+                Divider(modifier = Modifier.padding(horizontal = 16.dp), color = Purple40)
+                SettingItem(
+                    category = item,
+                    isEdit = editMode,
+                    onClicked = { },
+                    onLongClicked = { editMode, id -> onLongClicked(editMode, id) },
+                    onCheckedItem = { isChecked, id -> onCheckedItem(isChecked, id) }
+                ) {
+                    BothSideText(
+                        leftText = {
+                            Text(
+                                text = item.name ?: "",
+                                style = MaterialTheme.typography.subtitle2,
+                                color = Purple
+                            )
+                        },
+                        rightText = {
+                            LabelText(
+                                text = item.name ?: "",
+                                textStyle = MaterialTheme.typography.caption,
+                                color = if (item.color == null) OffWhite else Color(
+                                    android.graphics.Color.parseColor(
+                                        item.color
+                                    )
+                                )
+                            )
+                        }
+                    )
+                }
+            }
+        }
+    }
+    item {
+        Divider(color = Purple40)
+        AddItemText()
+    }
+    item {
+        Spacer(
+            modifier = Modifier
+                .height(1.dp)
+                .fillMaxWidth()
+                .background(LightPurple)
+        )
+    }
+}
+
+@Composable
+fun AddItemText() {
+    Row(
+        modifier = Modifier.padding(horizontal = 16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            modifier = Modifier.weight(1f),
+            text = "추가하기",
+            color = Purple,
+            style = MaterialTheme.typography.subtitle2
+        )
+
+        IconButton(onClick = {}) {
+            Icon(imageVector = IconPack.Plus, contentDescription = "plus", tint = Purple)
+        }
+    }
+}
+
+@Preview(showBackground = false)
+@Composable
+fun SettingScreenPreview() {
+    SettingScreen()
 }

--- a/app/src/main/java/com/woowa/accountbook/ui/settings/component/SettingScreen.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/settings/component/SettingScreen.kt
@@ -27,8 +27,14 @@ import com.woowa.accountbook.ui.settings.SettingViewModel
 import com.woowa.accountbook.ui.theme.*
 
 @Composable
-fun SettingScreen(settingViewModel: SettingViewModel = hiltViewModel()) {
+fun SettingScreen(
+    settingViewModel: SettingViewModel = hiltViewModel(),
+    onSectionItemClicked: (Int?, String) -> Unit = { _, _ -> }
+) {
 
+    settingViewModel.getPayments()
+    settingViewModel.getExpenseCategories()
+    settingViewModel.getIncomeCategories()
     val paymentEditMode = remember { mutableStateOf(false) }
     val expenseEditMode = remember { mutableStateOf(false) }
     val incomeEditMode = remember { mutableStateOf(false) }
@@ -52,15 +58,13 @@ fun SettingScreen(settingViewModel: SettingViewModel = hiltViewModel()) {
                         "${incomeCategories.count { it.isChecked }}개 선택",
                     navigationIcon = IconPack.LeftArrow,
                     onNavigationClicked = {
-                        if(paymentEditMode.value) {
+                        if (paymentEditMode.value) {
                             paymentEditMode.value = !paymentEditMode.value
                             settingViewModel.resetCheckedItem("payment")
-                        }
-                        else if(expenseEditMode.value) {
+                        } else if (expenseEditMode.value) {
                             expenseEditMode.value = !expenseEditMode.value
                             settingViewModel.resetCheckedItem("expense")
-                        }
-                        else {
+                        } else {
                             incomeEditMode.value = !incomeEditMode.value
                             settingViewModel.resetCheckedItem("income")
                         }
@@ -68,15 +72,13 @@ fun SettingScreen(settingViewModel: SettingViewModel = hiltViewModel()) {
                     actionIcon = IconPack.Trash,
                     actionIconColor = Red,
                     onActionClicked = {
-                        if(paymentEditMode.value) {
+                        if (paymentEditMode.value) {
                             paymentEditMode.value = !paymentEditMode.value
                             settingViewModel.removeItem("payment")
-                        }
-                        else if(expenseEditMode.value) {
+                        } else if (expenseEditMode.value) {
                             expenseEditMode.value = !expenseEditMode.value
                             settingViewModel.removeItem("expense")
-                        }
-                        else {
+                        } else {
                             incomeEditMode.value = !incomeEditMode.value
                             settingViewModel.removeItem("income")
                         }
@@ -97,7 +99,7 @@ fun SettingScreen(settingViewModel: SettingViewModel = hiltViewModel()) {
                 title = "결제수단",
                 payments = payments,
                 editMode = paymentEditMode.value,
-                onClicked = {},
+                onClicked = { onSectionItemClicked(it, "payment") },
                 onLongClicked = { mode, id ->
                     paymentEditMode.value = !mode
                     expenseEditMode.value = false
@@ -115,7 +117,7 @@ fun SettingScreen(settingViewModel: SettingViewModel = hiltViewModel()) {
                 title = "지출 카테고리",
                 category = expenseCategories,
                 editMode = expenseEditMode.value,
-                onClicked = {},
+                onClicked = { onSectionItemClicked(it, "expense") },
                 onLongClicked = { mode, id ->
                     paymentEditMode.value = false
                     expenseEditMode.value = !mode
@@ -133,7 +135,7 @@ fun SettingScreen(settingViewModel: SettingViewModel = hiltViewModel()) {
                 title = "수입 카테고리",
                 category = incomeCategories,
                 editMode = incomeEditMode.value,
-                onClicked = {},
+                onClicked = { onSectionItemClicked(it, "income") },
                 onLongClicked = { mode, id ->
                     paymentEditMode.value = false
                     expenseEditMode.value = false
@@ -156,7 +158,7 @@ private fun LazyListScope.section(
     payments: List<Payment> = emptyList(),
     category: List<Category> = emptyList(),
     editMode: Boolean = false,
-    onClicked: () -> Unit = {},
+    onClicked: (Int?) -> Unit = {},
     onLongClicked: (Boolean, Int?) -> Unit = { _, _ -> },
     onCheckedItem: (Boolean, Int?) -> Unit = { _, _ -> },
 ) {
@@ -170,7 +172,7 @@ private fun LazyListScope.section(
                 SettingItem(
                     payment = item,
                     isEdit = editMode,
-                    onClicked = { },
+                    onClicked = { onClicked(it) },
                     onLongClicked = { editMode, id -> onLongClicked(editMode, id) },
                     onCheckedItem = { isChecked, id -> onCheckedItem(isChecked, id) }
                 ) {
@@ -193,7 +195,7 @@ private fun LazyListScope.section(
                 SettingItem(
                     category = item,
                     isEdit = editMode,
-                    onClicked = { },
+                    onClicked = { onClicked(it) },
                     onLongClicked = { editMode, id -> onLongClicked(editMode, id) },
                     onCheckedItem = { isChecked, id -> onCheckedItem(isChecked, id) }
                 ) {
@@ -223,7 +225,7 @@ private fun LazyListScope.section(
     }
     item {
         Divider(color = Purple40)
-        AddItemText()
+        AddItemText(onClicked = { onClicked(it) })
     }
     item {
         Spacer(
@@ -236,7 +238,9 @@ private fun LazyListScope.section(
 }
 
 @Composable
-fun AddItemText() {
+fun AddItemText(
+    onClicked: (Int?) -> Unit
+) {
     Row(
         modifier = Modifier.padding(horizontal = 16.dp),
         verticalAlignment = Alignment.CenterVertically
@@ -248,7 +252,7 @@ fun AddItemText() {
             style = MaterialTheme.typography.subtitle2
         )
 
-        IconButton(onClick = {}) {
+        IconButton(onClick = { onClicked(-1) }) {
             Icon(imageVector = IconPack.Plus, contentDescription = "plus", tint = Purple)
         }
     }

--- a/app/src/main/java/com/woowa/accountbook/ui/settings/component/SettingScreen.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/settings/component/SettingScreen.kt
@@ -1,9 +1,30 @@
 package com.woowa.accountbook.ui.settings.component
 
-import androidx.compose.material.Text
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.Divider
+import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.woowa.accountbook.ui.component.AccountBookAppBar
+import com.woowa.accountbook.ui.theme.LightPurple
+import com.woowa.accountbook.ui.theme.OffWhite
 
 @Composable
 fun SettingScreen() {
-    Text(text = "설정 화면")
+    Scaffold(
+        backgroundColor = OffWhite,
+        topBar = {
+            AccountBookAppBar(title = "설정")
+        }
+    ) {
+        Divider(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(1.dp)
+                .background(LightPurple)
+        )
+    }
 }

--- a/app/src/main/java/com/woowa/accountbook/ui/statistics/component/StatisticsScreen.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/statistics/component/StatisticsScreen.kt
@@ -82,6 +82,12 @@ fun StatisticsScreen(
             )
         }
     ) {
+        Divider(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(1.dp)
+                .background(LightPurple)
+        )
         if (histories.isEmpty()) {
             Text(
                 modifier = Modifier

--- a/app/src/main/java/com/woowa/accountbook/ui/theme/Color.kt
+++ b/app/src/main/java/com/woowa/accountbook/ui/theme/Color.kt
@@ -46,3 +46,15 @@ val Yellow2 = Color(0xFFEBC374)
 val Yellow3 = Color(0xFFE1AD60)
 val Yellow4 = Color(0xFFE29C4D)
 val Yellow5 = Color(0xFFE39145)
+
+val expenseColorList = listOf(
+    Blue1, Blue2, Blue3, Blue4, Blue5,
+    Green1, Green2, Green3, Green4, Green5,
+    Purple1, Purple2, Purple3, Purple4, Purple5,
+    Pink1, Pink2, Pink3, Pink4, Pink5,
+)
+
+val incomeColorList = listOf(
+    Olive1, Olive2, Olive3, Olive4, Olive5,
+    Yellow1, Yellow2, Yellow3, Yellow4, Yellow5,
+)


### PR DESCRIPTION
### Issue

- closed #44

### Description

- AppBar Style 개선
  - 앱 바 하단 경계선 설정

- 설정화면 구성
  - 일반 모드
  - 수정 모드

- 설정화면 추가 구성
  - 추가 버튼(결제 수단, 수입, 지출 카테고리) 클릭시 추가화면으로 navigate
  - 내역 수정, 추가 화면 → 결제, 카테고리 화면 이동
 
- 중복 저장 처리
  - 카테고리, 결제 수단 중복 저장 처리
  - 카테고리(지출, 수입을 판단, 이름 판단 후 처리)
  - 결제 수단(이름 판단 후 처리)